### PR TITLE
Text DOM functions; Build output; Dep bumping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landmarks",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "scripts": {
     "pretest": "eslint .",
@@ -24,10 +24,10 @@
     "archiver": "~1.3",
     "chalk": "~1.1",
     "deepmerge": "~1.3",
-    "eslint": "~3.14",
+    "eslint": "~3.16",
     "fs-extra": "~1.0",
-    "jsdom": "~9.9",
-    "rimraf": "~2.5",
+    "jsdom": "~9.11",
+    "rimraf": "~2.6",
     "svg2png": "~4.1",
     "test": "~0.6"
   }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -19,7 +19,7 @@ const validBrowsers = Object.freeze([
 	'firefox',
 	'chrome'
 ])
-const buildModes = Object.freeze(validBrowsers + ['all'])
+const buildModes = Object.freeze(validBrowsers.concat(['all']))
 
 const browserPngSizes = {
 	'firefox': [
@@ -157,7 +157,7 @@ function makeZip(browser) {
 	const archive = archiver('zip')
 
 	output.on('close', function() {
-		console.log(chalk.green('✔ ') + archive.pointer() + ' total bytes for ' + outputFileName)
+		console.log(chalk.green('✔ ' + archive.pointer() + ' total bytes for ' + outputFileName))
 	})
 
 	archive.on('error', function(err) {

--- a/src/static/popup.js
+++ b/src/static/popup.js
@@ -12,10 +12,10 @@
 // If not, put a message there stating such.
 function handleLandmarksResponse(response) {
 	const display = document.getElementById('landmarks')
-	display.innerHTML = ''
+	removeChildNodes(display)
 
 	if (chrome.runtime.lastError) {
-		display.innerHTML = paras([
+		addText(display, [
 			errorString() + chrome.runtime.lastError.message,
 			chrome.i18n.getMessage('errorGettingLandmarksFromContentScript')
 		])
@@ -26,25 +26,35 @@ function handleLandmarksResponse(response) {
 	if (Array.isArray(response)) {
 		// Content script would normally send back an array
 		if (response.length === 0) {
-			display.innerHTML = paras(
-					chrome.i18n.getMessage('noLandmarksFound'))
+			addText(display, chrome.i18n.getMessage('noLandmarksFound'))
 		} else {
 			makeLandmarksTree(response, display)
 		}
 	} else if (response === 'wait') {
-		display.innerHTML = paras(chrome.i18n.getMessage('pageNotLoadedYet'))
+		addText(display, chrome.i18n.getMessage('pageNotLoadedYet'))
 	} else {
-		display.innerHTML = paras(
-				errorString() + 'content script sent: ' + response)
+		addText(display, errorString() + 'content script sent: ' + response)
 	}
 }
 
-// Return a string corresponding to an HTML paragraph containing message or,
-// if message is an array, a paragraph for each element of message
-function paras(message) {
-	return '<p>' +
-		(Array.isArray(message) ? message.join('</p><p>') : message) +
-		'</p>'
+// Remove all nodes contained within a node
+function removeChildNodes(element) {
+	while (element.firstChild) {
+		element.removeChild(element.firstChild)
+	}
+}
+
+// Append text paragraphs to the given element
+// 'text' can be a string, or array of strings
+function addText(element, text) {
+	const messages = Array.isArray(text) ? text : [text]
+
+	messages.forEach((message) => {
+		const newPara = document.createElement('p')
+		const newParaText = document.createTextNode(message)
+		newPara.appendChild(newParaText)
+		element.appendChild(newPara)
+	})
 }
 
 // Create a button that reloads the current page and add it to an element
@@ -52,7 +62,7 @@ function paras(message) {
 function addReloadButton(element) {
 	const button = document.createElement('button')
 	button.appendChild(document.createTextNode(
-				chrome.i18n.getMessage('tryReloading')))
+		chrome.i18n.getMessage('tryReloading')))
 	button.addEventListener('click', reloadActivePage)
 	element.appendChild(button)
 }


### PR DESCRIPTION
* Use text DOM functions instead of `.innerHTML` (fixes #45).
* Use green colour for the entirety of the "extension file written"
messages (not just the tick symbols), so that the positive meaning is
clear even on Windows, where the tick symbol is not visible.
* Bump Landmarks version (can't use '2.0.7-alpha' or similar because
Chrome doesn't like it).
* Correctly construct list of valid build modes in build script (the
noticeable effect is that the error message when running `node
scripts/build.js invalid-build-mode` now appears correctly).
* Bump dependencies (except fs-extra as that may need work).