### PR TITLE
Check all tabs wrt disabling the browser action

### DIFF
--- a/src/assemble/injector.js
+++ b/src/assemble/injector.js
@@ -3,7 +3,7 @@
 function landmarksContentScriptInjector() {
 	// Inject content script manually
 	browser.tabs.query({}, function(tabs) {
-		for(const i in tabs) {
+		for (const i in tabs) {
 			if (/^https?:\/\//.test(tabs[i].url)) {
 				browser.tabs.executeScript(tabs[i].id, {
 					file: 'compatibility.js'

--- a/src/static/background.js
+++ b/src/static/background.js
@@ -140,6 +140,8 @@ browser.runtime.onInstalled.addListener(function(details) {
 // When the extension is loaded, if it's loaded into a page that is not an
 // HTTP(S) page, then we need to disable the browser action button.  This is
 // not done by default on Chrome or Firefox.
-browser.tabs.query({active: true, currentWindow: true}, function(tabs) {
-	checkBrowserActionState(tabs[0].id, tabs[0].url)
+browser.tabs.query({}, function(tabs) {
+	for (const i in tabs) {
+		checkBrowserActionState(tabs[i].id, tabs[i].url)
+	}
 })


### PR DESCRIPTION
This checks all the tabs to see if they are HTTP(S) pages. It therefore
partly addresses #55—at least enough to release 2.0.7. It would be nice
if browser-specific 'pages to avoid' lists could be added, though.