### PR TITLE
Do not show hidden landmarks

### DIFF
--- a/src/static/content.finder.js
+++ b/src/static/content.finder.js
@@ -76,13 +76,6 @@ function LandmarksFinder(win, doc) {
 		}
 	}
 
-	// forEach for NodeList (as opposed to Arrays)
-	function doForEach(nodeList, callback) {
-		for (let i = 0; i < nodeList.length; i++) {
-			callback(nodeList[i])
-		}
-	}
-
 
 	//
 	// Functions that refer to document or window
@@ -92,8 +85,10 @@ function LandmarksFinder(win, doc) {
 	function getLandmarks(element, depth) {
 		if (!element) return
 
-		doForEach(element.childNodes, function(elementChild) {
+		element.childNodes.forEach(function(elementChild) {
 			if (elementChild.nodeType === win.Node.ELEMENT_NODE) {
+				if (isHidden(elementChild)) return
+
 				// Support HTML5 elements' native roles
 				let role = getRoleFromTagNameAndContainment(elementChild)
 
@@ -218,6 +213,17 @@ function LandmarksFinder(win, doc) {
 		}
 
 		return true
+	}
+
+	function isHidden(element) {
+		const style = win.getComputedStyle(element)
+		if (element.hasAttribute('hidden')
+			|| style.visibility === 'hidden'
+			|| style.display === 'none' ) {
+			return true
+		}
+
+		return false
 	}
 
 

--- a/test/data/hidden-by-css-display-none-inline.json
+++ b/test/data/hidden-by-css-display-none-inline.json
@@ -1,0 +1,9 @@
+{
+  "expected": [
+    {
+      "depth": 0,
+      "role": "main",
+      "label": null
+    }
+  ]
+}

--- a/test/data/hidden-by-css-display-none-nested.json
+++ b/test/data/hidden-by-css-display-none-nested.json
@@ -1,0 +1,9 @@
+{
+  "expected": [
+    {
+      "depth": 0,
+      "role": "main",
+      "label": null
+    }
+  ]
+}

--- a/test/data/hidden-by-css-display-none.json
+++ b/test/data/hidden-by-css-display-none.json
@@ -1,0 +1,9 @@
+{
+  "expected": [
+    {
+      "depth": 0,
+      "role": "main",
+      "label": null
+    }
+  ]
+}

--- a/test/data/hidden-by-css-visibility-hidden.json
+++ b/test/data/hidden-by-css-visibility-hidden.json
@@ -1,0 +1,9 @@
+{
+  "expected": [
+    {
+      "depth": 0,
+      "role": "main",
+      "label": null
+    }
+  ]
+}

--- a/test/data/hidden-by-html-hidden-attribute-nested.json
+++ b/test/data/hidden-by-html-hidden-attribute-nested.json
@@ -1,0 +1,9 @@
+{
+  "expected": [
+    {
+      "depth": 0,
+      "role": "main",
+      "label": null
+    }
+  ]
+}

--- a/test/data/hidden-by-html-hidden-attribute.json
+++ b/test/data/hidden-by-html-hidden-attribute.json
@@ -1,0 +1,9 @@
+{
+  "expected": [
+    {
+      "depth": 0,
+      "role": "main",
+      "label": null
+    }
+  ]
+}

--- a/test/fixtures/hidden-by-css-display-none-inline.html
+++ b/test/fixtures/hidden-by-css-display-none-inline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title></title>
+	</head>
+	<body>
+		<header style="display: none;">
+			<h1>Visually-hidden header</h1>
+		</header>
+		<main>
+			<p>Main content</p>
+		</main>
+	</body>
+</html>

--- a/test/fixtures/hidden-by-css-display-none-nested.html
+++ b/test/fixtures/hidden-by-css-display-none-nested.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title></title>
+		<style>
+			.hide {
+				display: none;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="hide">
+			<header>
+				<h1>Visually-hidden header</h1>
+			</header>
+		</div>
+		<main>
+			<p>Main content</p>
+		</main>
+	</body>
+</html>

--- a/test/fixtures/hidden-by-css-display-none.html
+++ b/test/fixtures/hidden-by-css-display-none.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title></title>
+		<style>
+			header {
+				display: none;
+			}
+		</style>
+	</head>
+	<body>
+		<header>
+			<h1>Visually-hidden header</h1>
+		</header>
+		<main>
+			<p>Main content</p>
+		</main>
+	</body>
+</html>

--- a/test/fixtures/hidden-by-css-visibility-hidden.html
+++ b/test/fixtures/hidden-by-css-visibility-hidden.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title></title>
+		<style>
+			footer {
+				visibility: hidden;
+			}
+		</style>
+	</head>
+	<body>
+		<main>
+			<p>Main content</p>
+		</main>
+		<footer>
+			<p>Visually-hidden footer</p>
+		</footer>
+	</body>
+</html>

--- a/test/fixtures/hidden-by-html-hidden-attribute-nested.html
+++ b/test/fixtures/hidden-by-html-hidden-attribute-nested.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title></title>
+	</head>
+	<body>
+		<div hidden>
+			<header>
+				<h1>Visually-hidden header</h1>
+			</header>
+		</div>
+		<main>
+			<p>Main content</p>
+		</main>
+	</body>
+</html>

--- a/test/fixtures/hidden-by-html-hidden-attribute.html
+++ b/test/fixtures/hidden-by-html-hidden-attribute.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title></title>
+	</head>
+	<body>
+		<header hidden>
+			<h1>Visually-hidden header</h1>
+		</header>
+		<main>
+			<p>Main content</p>
+		</main>
+	</body>
+</html>


### PR DESCRIPTION
* If an element is hidden, ignore it and any landmark it
represents and contains (fixes #80).
* Also we can use NodeList.forEach() now (fixes #83).