### PR TITLE
Restore outline and outline-offset inline CSS values (if specified)

### DIFF
--- a/src/static/content.focusing.js
+++ b/src/static/content.focusing.js
@@ -69,12 +69,20 @@ function ElementFocuser() {
 	// Private API
 	//
 
+	let previousOutline
+	let previousOutlineOffset
+
 	function addBorder(element) {
+		previousOutline = element.style.outline || null
+		previousOutlineOffset = element.style.outlineOffset || null
 		element.style.outline = '5px solid red'
 		element.style.outlineOffset = '-3px'
 	}
 
 	function removeBorder(element) {
-		element.style.outline = null
+		element.style.outline = previousOutline
+		element.style.outlineOffset = previousOutlineOffset
+		previousOutline = null
+		previousOutlineOffset = null
 	}
 }

--- a/test/manual-test-outline-restoration.html
+++ b/test/manual-test-outline-restoration.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title>Test if elements' outlines are correctly restored</title>
+		<style>
+			.outline-from-stylesheet {
+				outline: 2px dashed blue;
+				outline-offset: 5px;
+			}
+
+			section {
+				padding: 10px;
+			}
+		</style>
+	</head>
+	<body>
+		<header>
+			<h1>Test if elements' outlines are correctly restored</h1>
+		</header>
+		<main>
+			<section class="outline-from-stylesheet" aria-labelledby="test-area-1-heading">
+				<h2 id="test-area-1-heading">Test Area 1</h2>
+				<p>This <code>&lt;section&gt;</code> gets its outline from the stylesheet.</p>
+			</section>
+			<section style="outline-offset: -10px; outline: 2px dashed green;" aria-labelledby="test-area-2-heading">
+				<h2 id="test-area-2-heading">Test Area 2</h2>
+				<p>This <code>&lt;section&gt;</code> uses inline styles.</p>
+			</section>
+			<section style="outline-offset: -5px; outline-width: 2px; outline-style: dashed; outline-color: orange;" aria-labelledby="test-area-3-heading">
+				<h2 id="test-area-3-heading">Test Area 3</h2>
+				<p>This <code>&lt;section&gt;</code> uses inline styles with each sub-property of <code>outline</code> specified separately.</p>
+			</section>
+			<section style="outline: 2px dashed DeepPink;" aria-labelledby="test-area-4-heading">
+				<h2 id="test-area-4-heading">Test Area 4</h2>
+				<p>This <code>&lt;section&gt;</code> uses inline styles, but doesn't define <code>outline-offset</code>.</p>
+			</section>
+		</main>
+		<footer>
+			<p>Footer.</p>
+		</footer>
+	</body>
+</html>


### PR DESCRIPTION
Fixes #54.