### PR TITLE
Fix ESLint errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,7 +37,7 @@
     "no-undef": "error",
     "no-unexpected-multiline": "error",
     "no-unused-expressions": "error",
-    "no-unused-vars": "warn",
+    "no-unused-vars": "error",
     "no-use-before-define": [
       "error",
       {

--- a/src/assemble/injector.js
+++ b/src/assemble/injector.js
@@ -1,4 +1,5 @@
 'use strict'
+/* exported landmarksContentScriptInjector */
 
 function landmarksContentScriptInjector() {
 	// Inject content script manually

--- a/src/static/background.js
+++ b/src/static/background.js
@@ -26,7 +26,7 @@ browser.commands.onCommand.addListener(function(command) {
 //    startup, URL changes are going on in all tabs.
 //  * The content script will send an 'update-badge' message back to us when
 //    the landmarks have been found.
-browser.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
+browser.tabs.onUpdated.addListener(function(tabId, changeInfo) {
 	if (!changeInfo.url) {
 		return
 	}
@@ -63,7 +63,7 @@ function startsWith(string, pattern) {
 //       'same URL' filtering.
 browser.webNavigation.onHistoryStateUpdated.addListener(function(details) {
 	if (details.frameId === 0) {
-		browser.tabs.get(details.tabId, function(tab) {
+		browser.tabs.get(details.tabId, function() {
 			browser.tabs.sendMessage(
 				details.tabId,
 				{request: 'trigger-refresh'}
@@ -81,7 +81,7 @@ browser.webNavigation.onHistoryStateUpdated.addListener(function(details) {
 
 // When the content script has loaded and any landmarks found, it will let us
 // konw, so we can set the browser action badge.
-browser.runtime.onMessage.addListener(function(message, sender, sendResponse) {
+browser.runtime.onMessage.addListener(function(message, sender) {
 	switch (message.request) {
 		case 'update-badge':
 			landmarksBadgeUpdate(sender.tab.id, message.landmarks)

--- a/src/static/content.finder.js
+++ b/src/static/content.finder.js
@@ -1,4 +1,5 @@
 'use strict'
+/* exported LandmarksFinder */
 
 function LandmarksFinder(win, doc) {
 	//

--- a/src/static/content.focusing.js
+++ b/src/static/content.focusing.js
@@ -1,4 +1,5 @@
 'use strict'
+/* exported ElementFocuser */
 
 function ElementFocuser() {
 	let currentlySelectedElement

--- a/src/static/sendToActiveTab.js
+++ b/src/static/sendToActiveTab.js
@@ -1,4 +1,5 @@
 'use strict'
+/* exported sendToActiveTab */
 
 function sendToActiveTab(message, callback) {
 	browser.tabs.query({active: true, currentWindow: true}, function(tabs) {


### PR DESCRIPTION
* Use the exported comment directive (fixes #75).
* Clean up the other ESLint warnings by removing refs to function
parameters that are not being used (had originally thought this bad
form, but seems to work fine in Chrome and Firefox).
* Re-make unused-vars a full error.