### PR TITLE
Fix unintended possible infinite loop

### DIFF
--- a/src/static/content.management.js
+++ b/src/static/content.management.js
@@ -103,7 +103,7 @@ function bootstrap() {
 			lf.find()
 			sendUpdateBadgeMessage()
 		} else if (landmarkFindingAttempts <= maximumAttempts) {
-			setTimeout(bootstrap, attemptInterval)
+			setTimeout(_bootstrap, attemptInterval)
 		} else {
 			throw new Error('Landmarks: unable to find landmarks after ' +
 				String(maximumAttempts) + 'attempts.')


### PR DESCRIPTION
The bootstrap() fucntion actually calls an internal function called
_bootstrap() (with an underscore at the start) during the loop where it
checks for landmarks on the page. This internal function accidentally
called the outer one if it had to retry, thus resetting the counter back
to 0.