### PR TITLE
DRY up the manifests

### DIFF
--- a/src/assemble/compatibility.js
+++ b/src/assemble/compatibility.js
@@ -1,0 +1,5 @@
+'use strict'
+
+window.browser = (function() {
+	return window.msBrowser || window.chrome
+})()

--- a/src/assemble/manifest.chrome.json
+++ b/src/assemble/manifest.chrome.json
@@ -2,7 +2,6 @@
   "icons": {
     "16": "landmarks-16.png",
     "32": "landmarks-32.png",
-    "48": "landmarks-48.png",
     "128": "landmarks-128.png"
   },
 
@@ -18,15 +17,14 @@
   },
 
   "background": {
-    "scripts": [
-      "compatibility.js",
-      "sendToActiveTab.js",
-      "injector.js",
-      "background.js"
-    ]
+    "scripts": ["compatibility.js"]
   },
 
-  "permissions": [
-    "<all_urls>", "storage", "webNavigation", "tabs"
-  ]
+  "content_scripts": [
+    {
+      "js": ["compatibility.js"]
+    }
+  ],
+
+  "permissions": ["<all_urls>"]
 }

--- a/src/assemble/manifest.common.json
+++ b/src/assemble/manifest.common.json
@@ -8,11 +8,21 @@
   "homepage_url": "http://matatk.agrip.org.uk/landmarks/",
   "default_locale": "en_GB",
 
+  "icons": {
+    "48": "landmarks-48.png"
+  },
+
+  "background": {
+    "scripts": [
+      "sendToActiveTab.js",
+      "background.js"
+    ]
+  },
+
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
       "js": [
-        "compatibility.js",
         "content.finder.js",
         "content.focusing.js",
         "content.management.js"
@@ -42,5 +52,11 @@
   "browser_action": {
     "default_title": "Landmarks",
     "default_popup": "popup.html"
-  }
+  },
+
+  "permissions": [
+    "storage",
+    "webNavigation",
+    "tabs"
+  ]
 }

--- a/src/assemble/manifest.firefox.json
+++ b/src/assemble/manifest.firefox.json
@@ -1,6 +1,5 @@
 {
   "icons": {
-    "48": "landmarks-48.png",
     "96": "landmarks-96.png"
   },
 
@@ -19,13 +18,5 @@
       "id": "ariaLandmarkNav@ibm.com",
       "strict_min_version": "53.0"
     }
-  },
-
-  "background": {
-    "scripts": ["compatibility.js", "sendToActiveTab.js", "background.js"]
-  },
-
-  "permissions": [
-    "storage", "webNavigation", "tabs"
-  ]
+  }
 }

--- a/src/assemble/manifest.opera.json
+++ b/src/assemble/manifest.opera.json
@@ -1,7 +1,6 @@
 {
   "icons": {
     "16": "landmarks-16.png",
-    "48": "landmarks-48.png",
     "128": "landmarks-128.png"
   },
 
@@ -15,15 +14,14 @@
   "minimum_opera_version": "44",
 
   "background": {
-    "scripts": [
-      "compatibility.js",
-      "sendToActiveTab.js",
-      "injector.js",
-      "background.js"
-    ]
+    "scripts": ["compatibility.js"]
   },
 
-  "permissions": [
-    "<all_urls>", "storage", "webNavigation", "tabs"
-  ]
+ "content_scripts": [
+    {
+      "js": ["compatibility.js"]
+    }
+  ],
+
+  "permissions": ["<all_urls>"]
 }

--- a/src/static/compatibility.js
+++ b/src/static/compatibility.js
@@ -1,7 +1,0 @@
-'use strict'
-
-window.browser = (function() {
-	return window.msBrowser ||
-		window.browser ||
-		window.chrome
-})()


### PR DESCRIPTION
* This puts more stuff into the common manifest fragment, including bits
of keys and even bits of arrays (such as the lists of background and
content scripts).
* Only include the compatibility script on !Firefox (Fixes #91).