### PR TITLE
Focusing; Timing

### DIFF
--- a/src/static/content.focusing.js
+++ b/src/static/content.focusing.js
@@ -38,9 +38,7 @@ function ElementFocuser() {
 				addBorder(element)
 
 				if (borderTypePref === 'momentary') {
-					setTimeout(function() {
-						removeBorder(element)
-					}, 2000)
+					setTimeout(() => removeBorder(element), 2000)
 				}
 			}
 
@@ -70,20 +68,21 @@ function ElementFocuser() {
 	// Private API
 	//
 
-	let previousOutline
-	let previousOutlineOffset
-
 	function addBorder(element) {
-		previousOutline = element.style.outline || null
-		previousOutlineOffset = element.style.outlineOffset || null
+		element.dataset.landmarksOriginalOutline = element.style.outline
+		element.dataset.landmarksOriginalOutlineOffset =
+			element.style.outlineOffset
+
 		element.style.outline = '5px solid red'
 		element.style.outlineOffset = '-3px'
 	}
 
 	function removeBorder(element) {
-		element.style.outline = previousOutline
-		element.style.outlineOffset = previousOutlineOffset
-		previousOutline = null
-		previousOutlineOffset = null
+		element.style.outline = element.dataset.landmarksOriginalOutline
+		element.style.outlineOffset =
+			element.dataset.landmarksOriginalOutlineOffset
+
+		element.removeAttribute('data-landmarks-original-outline')
+		element.removeAttribute('data-landmarks-original-outline-offset')
 	}
 }

--- a/src/static/content.management.js
+++ b/src/static/content.management.js
@@ -91,10 +91,14 @@ function sendUpdateBadgeMessage() {
 // Content Script Entry Point
 //
 
+// Most pages I've tried have got to a readyState of 'complete' within 10-100ms.
+// Therefore this should easily be sufficient.
 function bootstrap() {
-	const attemptInterval = 2000
-	const maximumAttempts = 10
+	const attemptInterval = 500
+	const maximumAttempts = 4
 	let landmarkFindingAttempts = 0
+	const bootstrapTime = performance.now()
+
 	lf.reset()
 	sendUpdateBadgeMessage()
 
@@ -103,17 +107,18 @@ function bootstrap() {
 		lf.find()
 		const end = performance.now()
 		console.log(`Landmarks: took ${Math.round(end - start)}ms `
-			+ `to find landmarks on ${window.location}`)
+			+ `to find landmarks on ${window.location} `
+			+ `${Math.round(end - bootstrapTime)}ms after booting `
+			+ `(${landmarkFindingAttempts} attempts)`)
 	}
 
 	function bootstrapCore() {
 		landmarkFindingAttempts += 1
-		console.log(`Landmarks: attempt ${landmarkFindingAttempts} `
-			+ `at ${new Date().toLocaleTimeString()}`)
+
 		if (document.readyState === 'complete') {
 			timeFind()
 			sendUpdateBadgeMessage()
-		} else if (landmarkFindingAttempts <= maximumAttempts) {
+		} else if (landmarkFindingAttempts < maximumAttempts) {
 			setTimeout(bootstrapCore, attemptInterval)
 		} else {
 			throw new Error('Landmarks: unable to find landmarks '
@@ -121,7 +126,6 @@ function bootstrap() {
 		}
 	}
 
-	console.log(`Landmarks: bootstrapping - ${new Date().toLocaleTimeString()}`)
 	setTimeout(bootstrapCore, attemptInterval)
 }
 


### PR DESCRIPTION
* Use the DOM to store elements' previous outline properties, so as to
keep the state there and keep the code simple. It aims to be as clean
to the DOM as can be. Fixes #54 (again, and properly :-)).
* From studying how long pages take to get to the 'complete' readyState
in practice, the previous number and interval of attempts was way too
much: reduce the delay time to 500ms (still way above what seems to be
necessary) and only make four attempts.