### PR TITLE
Special pages

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -95,6 +95,14 @@ function copyStaticFiles(browser) {
 }
 
 
+function copySpecialPagesFile(browser) {
+	logStep(`Copying special pages file for ${browser}...`)
+	fse.copySync(
+		path.join(srcAssembleDir, `specialPages.${browser}.js`),
+		path.join(pathToBuild(browser), 'specialPages.js'))
+}
+
+
 function mergeManifest(browser) {
 	logStep('Merging manifest.json...')
 	const common = path.join('..', srcAssembleDir, 'manifest.common.json')
@@ -185,6 +193,7 @@ browsers.forEach((browser) => {
 	logStep(chalk.bold(`Building for ${browser}...`))
 
 	copyStaticFiles(browser)
+	copySpecialPagesFile(browser)
 	mergeManifest(browser)
 	copyCompatibilityShimAndContentScriptInjector(browser)
 	getPngs(sp, browser)

--- a/src/assemble/manifest.common.json
+++ b/src/assemble/manifest.common.json
@@ -15,6 +15,7 @@
   "background": {
     "scripts": [
       "sendToActiveTab.js",
+      "specialPages.js",
       "background.js"
     ]
   },

--- a/src/assemble/specialPages.chrome.js
+++ b/src/assemble/specialPages.chrome.js
@@ -1,0 +1,6 @@
+'use strict'
+/* exported specialPages */
+
+const specialPages = Object.freeze([
+	/^https:\/\/chrome.google.com\/webstore/
+])

--- a/src/assemble/specialPages.firefox.js
+++ b/src/assemble/specialPages.firefox.js
@@ -1,0 +1,6 @@
+'use strict'
+/* exported specialPages */
+
+const specialPages = Object.freeze([
+	/^https:\/\/addons.mozilla.org/
+])

--- a/src/assemble/specialPages.opera.js
+++ b/src/assemble/specialPages.opera.js
@@ -1,0 +1,6 @@
+'use strict'
+/* exported specialPages */
+
+const specialPages = Object.freeze([
+	/^https:\/\/addons.opera.com/
+])

--- a/src/static/background.js
+++ b/src/static/background.js
@@ -1,5 +1,5 @@
 'use strict'
-/* global sendToActiveTab landmarksContentScriptInjector */
+/* global sendToActiveTab landmarksContentScriptInjector specialPages */
 
 //
 // Keyboard Shortcut Handling
@@ -43,6 +43,13 @@ browser.webNavigation.onCompleted.addListener(function(details) {
 
 function checkBrowserActionState(tabId, url) {
 	if (/^(https?|file):\/\//.test(url)) {  // TODO DRY
+		for (const specialPage of specialPages) {
+			if (specialPage.test(url)) {
+				console.log(`Landmarks: disabling extension on ${url}`)
+				browser.browserAction.disable(tabId)
+				return
+			}
+		}
 		browser.browserAction.enable(tabId)
 	} else {
 		browser.browserAction.disable(tabId)


### PR DESCRIPTION
* Disable the browserAction on pages that need the extension disabled
for security reasons (i.e. the browsers' add-on sites).
* It doesn't appear necessary to disable the keyboard shortcuts
manually; the browsers must do this for us.
* Fixes #55.