### PR TITLE
Test nested siblings

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,13 +175,16 @@ This is a fork of the [original landmarks extension](https://github.com/davidtod
 Changes
 -------
 
+- 2.1.0 - ??th of November 2017
+    -   Landmarks will be updated even if the page changes dynamically [[#111]](https://github.com/matatk/landmarks/pull/111)
+    -   Fix a bug whereby sibling landmarks may not be identified as such [[#???]](???)
 - 2.0.8 - 18th of September 2017
-    -   [Landmarks now ignores hidden regions](https://github.com/matatk/landmarks/pull/85).
-    -   [Fix a bug that caused the pop-up to incorrectly report nesting that changes by >1 level between landmarks](https://github.com/matatk/landmarks/pull/102). (Documents shouldn't really do this, but the extension should point out correctly when they do.)
-    -   [Correctly restore elements' outlines after they are highlighted](https://github.com/matatk/landmarks/pull/94).
-    -   [Automatically disable the extension on browsers' extensions store pages](https://github.com/matatk/landmarks/pull/97).
-    -   [Start exploring what's needed for Edge support in future](https://github.com/matatk/landmarks/pull/99).
-    -   [Improvements to the SVG to PNG process](https://github.com/matatk/landmarks/pull/95).
+    -   Landmarks now ignores hidden regions [[#85]](https://github.com/matatk/landmarks/pull/85).
+    -   Fix a bug that caused the pop-up to incorrectly report nesting that changes by >1 level between landmarks [[#102]](https://github.com/matatk/landmarks/pull/102). (Documents shouldn't really do this, but the extension should point out correctly when they do.)
+    -   Correctly restore elements' outlines after they are highlighted [[#94]](https://github.com/matatk/landmarks/pull/94).
+    -   Automatically disable the extension on browsers' extensions store pages [[#97]](https://github.com/matatk/landmarks/pull/97).
+    -   Start exploring what's needed for Edge support in future [[#99]](https://github.com/matatk/landmarks/pull/99).
+    -   Improvements to the SVG to PNG process [[#95]](https://github.com/matatk/landmarks/pull/95).
     -   Other more minor tweaks and fixes.
     -   README updates.
 -   2.0.7 - 11th of May 2017

--- a/src/static/content.finder.js
+++ b/src/static/content.finder.js
@@ -88,23 +88,11 @@ function LandmarksFinder(win, doc) {
 
 
 	//
-	// Utilities
-	//
-
-	function getLastLandmarkedElement() {
-		const lastInfo = landmarks[landmarks.length - 1]
-		if (lastInfo) {
-			return lastInfo.element
-		}
-	}
-
-
-	//
 	// Functions that refer to document or window
 	//
 
 	// Recursive function for building list of landmarks from a root element
-	function getLandmarks(element, depth) {
+	function getLandmarks(element, depth, parentLandmark) {
 		if (element === undefined) return
 
 		element.childNodes.forEach(function(elementChild) {
@@ -127,8 +115,7 @@ function LandmarksFinder(win, doc) {
 
 				// Add the element if it should be considered a landmark
 				if (role && isLandmark(role, label)) {
-					const lastLandmark = getLastLandmarkedElement()
-					if (lastLandmark && isDescendant(lastLandmark, elementChild)) {
+					if (parentLandmark && isDescendant(parentLandmark, elementChild)) {
 						depth = depth + 1
 					}
 
@@ -139,21 +126,24 @@ function LandmarksFinder(win, doc) {
 						'element': elementChild
 					})
 
+					// Was this element selected before we were called (i.e.
+					// before the page was dynamically updated)?
 					if (selectedElement === elementChild) {
 						currentlySelectedIndex = landmarks.length - 1
 					}
 
-					// This actually tracks only the /last/ element that
-					// was marked up as main.
-					// TODO: Track the first only?
-					if (role === 'main') {
+					// If this is the first main landmark (there should only
+					// be one), store a reference to it.
+					if (mainElementIndex < 0 && role === 'main') {
 						mainElementIndex = landmarks.length - 1
 					}
+
+					parentLandmark = elementChild
 				}
 			}
 
 			// Recursively traverse the tree structure of the child node
-			getLandmarks(elementChild, depth)
+			getLandmarks(elementChild, depth, parentLandmark)
 		})
 	}
 

--- a/test/data/nested-siblings.json
+++ b/test/data/nested-siblings.json
@@ -1,0 +1,7 @@
+{
+  "expected": [
+    { "depth": 0, "role": "main", "label": null },
+    { "depth": 1, "role": "region", "label": "Sibling One" },
+    { "depth": 1, "role": "region", "label": "Sibling Two" }
+  ]
+}

--- a/test/fixtures/nested-siblings.html
+++ b/test/fixtures/nested-siblings.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title></title>
+	</head>
+	<body>
+		<main>
+			<div>
+				<div role="region" aria-label="Sibling One"></div>
+			</div>
+			<div>
+				<div role="region" aria-label="Sibling Two"></div>
+			</div>
+		</main>
+	</body>
+</html>


### PR DESCRIPTION
* Fix the sibling landmark depth bug (closes #108).
* Track only the first main landmark (there should be only
one; this feels better than tracking the last).
* Update README with main changes for 2.1.0.