### PR TITLE
Fix shouldRefresh logic

### DIFF
--- a/src/static/content.management.js
+++ b/src/static/content.management.js
@@ -136,6 +136,7 @@ function shouldRefreshLandmarkss(mutations) {
 				if (/display|visibility/.test(mutation.target.getAttribute('style'))) {
 					return true
 				}
+				continue
 			}
 
 			// TODO: things that could be checked:


### PR DESCRIPTION
When a style attribute change is detected and it is decided to not
relate to visibility, continue to the next mutation record.