### PR TITLE
For Opera, give the options page a title

### DIFF
--- a/src/static/_locales/en_GB/messages.json
+++ b/src/static/_locales/en_GB/messages.json
@@ -60,6 +60,10 @@
 
 
 
+  "prefsTitle": {
+    "message": "Landmarks Options"
+  },
+
 	"prefsBorderType": {
 		"message": "Border type:"
 	},

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8">
-		<title></title>
+		<title data-message="prefsTitle"></title>
 	</head>
 	<body>
 		<div>


### PR DESCRIPTION
* This does not show up in other browsers, but does in Opera as the
options page appears as a standalone page.
* Fixes #134.