### PR TITLE
Save options as they're changed; Update borders immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Please bear in mind the following when implementing landmarks...
 
     **Rule of thumb:** Use as few landmarks as possible, but ensure that all of the content on the page is within a landmark region.
 
--   If you're using HTML 5 elements such as `<header>`, `<nav>`, `<main>` and others, then your page will inherit some landmarks automagically. However it can be really helpful to label them (especially if there's more than one of a landmark on a page, such as a separate site-wide and page-local `<nav>`). The W3C documentation has all the details, but essentialy you would use either the `aria-labelledby` or `aria-label` attribute.
+-   If you're using HTML 5 elements such as `<header>`, `<nav>`, `<main>` and others, then your page will inherit some landmarks automagically. However it can be really helpful to label them (especially if there's more than one of a landmark on a page, such as a separate site-wide and page-local `<nav>`). The W3C documentation has all the details, but essentially you would use either the `aria-labelledby` or `aria-label` attribute.
 
     **Rule of thumb:** If you've more than one type of landmark, then be sure to label them, so their purpose is clear.
 
@@ -203,8 +203,9 @@ This is a fork of the [original landmarks extension](https://github.com/davidtod
 Changes
 -------
 
--   2.3.0 - 8th of May 2018
+-   2.3.0 - ??th of May 2018
     -   Add landmark labels to the border, which is now drawn more robustly and has customisable colour. \[[\#158](https://github.com/matatk/landmarks/pull/158)\]
+    -   Options are saved as they're changed by the user, and borders get updated to reflect settings changes immediately. \[[\#160](https://github.com/matatk/landmarks/pull/160)\]
     -   Minor tweaks to documentation and LICENCE dates. \[[\#159](https://github.com/matatk/landmarks/pull/159)\]
 -   2.2.0 - 18th of February 2018
     -   Support [Digital Publishing ARIA module](https://www.w3.org/TR/dpub-aria-1.0/) landmarks, and makes landmark role names friendly and translatable. \[[\#150](https://github.com/matatk/landmarks/pull/150)\]

--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ You can get to the extension's settings as follows.
 -   **Firefox:** Menu ☰ → Add-ons → Extensions \[on left-hand side, if not already activated\] → Preferences \[under Landmarks, then scroll down\]
 -   **Chrome/Opera:** Right-click on, or activate the context menu of, the Landmarks button in the toolbar → Options
 
-**Remember to use the "Save" button to save any changes.** Also, due to the varied way in which web pages can be styled, the border will sometimes not appear to fully surround the landmark element.
-
 This Extension's Support for Landmarks
 --------------------------------------
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -136,16 +136,16 @@ function checkMessages() {
 	for (const messageName in messages) {
 		messageSummary[messageName] = 0
 
-		if (messageName.startsWith('role')) {
-			// The role names' calls are constructed dynamically (and are
-			// probably OK).
-			messageSummary[messageName] = '?'
-		}
-
 		for (const file of files) {
 			messageSummary[messageName] +=
 				(fs.readFileSync(file).toString().match(
 					new RegExp(messageName, 'g')) || []).length
+		}
+
+		if (messageName.startsWith('role')) {
+			// The role names' calls are constructed dynamically (and are
+			// probably OK).
+			messageSummary[messageName] = '(not checked)'
 		}
 	}
 

--- a/src/static/_locales/en_GB/messages.json
+++ b/src/static/_locales/en_GB/messages.json
@@ -88,14 +88,6 @@
     "message": "Show debugging info in the console"
   },
 
-  "prefsSaveButton": {
-    "message": "Save"
-  },
-
-  "prefsSaved": {
-    "message": "Options saved"
-  },
-
 
 
 

--- a/src/static/content.focusing.js
+++ b/src/static/content.focusing.js
@@ -1,6 +1,7 @@
 'use strict'
 /* exported ElementFocuser */
 /* global landmarkName defaultBorderSettings ContrastChecker */
+// TODO redraw/update border if it's persistent and settings change
 
 function ElementFocuser() {
 	const momentaryBorderTime = 2000

--- a/src/static/content.focusing.js
+++ b/src/static/content.focusing.js
@@ -1,34 +1,50 @@
 'use strict'
 /* exported ElementFocuser */
 /* global landmarkName defaultBorderSettings ContrastChecker */
-// TODO redraw/update border if it's persistent and settings change
 
 function ElementFocuser() {
 	const momentaryBorderTime = 2000
 	let justMadeChanges = false
-	let currentlyFocusedElementBorder = null
-	let currentResizeHandler = null
-	let timer = null
+	let currentlyFocusedElementInfo = null    // keep for border redraws
+	let currentlyFocusedElementBorder = null  // indicates if border is shown
+	let borderRemovalTimer = null
 
+	const settings = {}         // caches options locally (for simpler code)
+	let labelFontColour = null  // computed based on border colour
 	const contrastChecker = new ContrastChecker()
 
-	// Get settings and keep them up-to-date
-	const settings = {}
-	let labelFontColour = null
+	let currentBorderResizeHandler = null
 
+
+	//
+	// Options-handling
+	//
+
+	// Take a local copy of all options at the start (this means that 'gets' of
+	// options don't need to be done asynchronously in the rest of the code).
+	// This also computes the initial label font colour (as it depends on the
+	// border colour, which forms the label's background).
 	browser.storage.sync.get(defaultBorderSettings, function(items) {
 		for (const option in items) {
 			settings[option] = items[option]
 		}
-		setLabelFontColour()
+		updateLabelFontColour()
 	})
 
 	browser.storage.onChanged.addListener(function(changes) {
 		for (const option in changes) {
 			if (settings.hasOwnProperty(option)) {
 				settings[option] = changes[option].newValue
-				checkLabelFontColour(option)
 			}
+		}
+
+		if ('borderColour' in changes || 'borderLabelFontSize' in changes) {
+			updateLabelFontColour()
+			redrawBorder()
+		}
+
+		if ('borderType' in changes) {
+			borderTypeChange()
 		}
 	})
 
@@ -46,58 +62,62 @@ function ElementFocuser() {
 	//       for this is done in the main content script, as it involves UI
 	//       activity, and couples finding and focusing.
 	this.focusElement = function(elementInfo) {
-		const element = elementInfo.element
-		const type = settings.borderType
-		const appearance = {  // passed to lower-level drawing code
-			colour: settings.borderColour,
-			fontColour: labelFontColour,
-			fontSize: settings.borderLabelFontSize
-		}
-
-		this.removeBorderOnCurrentlySelectedElement()
+		removeBorderOnCurrentlySelectedElement()
 
 		// Ensure that the element is focusable
-		const originalTabindex = element.getAttribute('tabindex')
+		const originalTabindex = elementInfo.element.getAttribute('tabindex')
 		if (originalTabindex === null || originalTabindex === '0') {
-			element.setAttribute('tabindex', '-1')
+			elementInfo.element.setAttribute('tabindex', '-1')
 		}
 
-		element.scrollIntoView()  // always go to the top of it
-		element.focus()
+		elementInfo.element.scrollIntoView()  // always go to the top of it
+		elementInfo.element.focus()
 
-		// Add the border and set a timer to remove it (if required by user)
-		if (type === 'persistent' || type === 'momentary') {
-			addBorder(element, landmarkName(elementInfo), appearance)
+		// Add the border and set a borderRemovalTimer to remove it (if
+		// required by user settings)
+		if (settings.borderType !== 'none') {
+			addBorder(elementInfo)
 
-			if (type === 'momentary') {
-				if (timer) {
-					clearTimeout(timer)
+			if (settings.borderType === 'momentary') {
+				if (borderRemovalTimer) {
+					clearTimeout(borderRemovalTimer)
 				}
-				timer = setTimeout(
-					this.removeBorderOnCurrentlySelectedElement,
+
+				borderRemovalTimer = setTimeout(
+					removeBorderOnCurrentlySelectedElement,
 					momentaryBorderTime)
 			}
 		}
 
 		// Restore tabindex value
 		if (originalTabindex === null) {
-			element.removeAttribute('tabindex')
+			elementInfo.element.removeAttribute('tabindex')
 		} else if (originalTabindex === '0') {
-			element.setAttribute('tabindex', '0')
+			elementInfo.element.setAttribute('tabindex', '0')
 		}
+
+		currentlyFocusedElementInfo = elementInfo
 	}
 
-	this.removeBorderOnCurrentlySelectedElement = function() {
+	function removeBorderOnCurrentlySelectedElement() {
 		if (currentlyFocusedElementBorder) {
 			justMadeChanges = true
 			currentlyFocusedElementBorder.remove()
-			window.removeEventListener('resize', currentResizeHandler)
+			window.removeEventListener('resize', currentBorderResizeHandler)
 			currentlyFocusedElementBorder = null
 		}
+
+		// currentlyFocusedElementInfo is not deleted, as we may be in the
+		// middle of updating (redrawing) a border due to settings changes
 	}
 
-	// Did we just make changes to a border? If so the mutations can be
-	// ignored.
+	// This needs to be a separate (and public) declaration because external
+	// stuff calls it, but the options-handling code can't access 'this'.
+	this.removeBorderOnCurrentlySelectedElement
+		= removeBorderOnCurrentlySelectedElement
+
+	// Did we just make changes to a border? If so, report this, so that the
+	// mutation observer can ignore it.
 	this.didJustMakeChanges = function() {
 		const didChanges = justMadeChanges
 		justMadeChanges = false
@@ -109,29 +129,27 @@ function ElementFocuser() {
 	// Private API
 	//
 
-	// Given an element on the page and an element acting as the border, size
-	// the border appropriately for the element
-	function sizeBorder(element, border) {
-		const bounds = element.getBoundingClientRect()
-		border.style.left = window.scrollX + bounds.left + 'px'
-		border.style.top = window.scrollY + bounds.top + 'px'
-		border.style.width = bounds.width + 'px'
-		border.style.height = bounds.height + 'px'
+	// Add the landmark border and label for an element
+	// Note: only one should be drawn at a time
+	function addBorder(elementInfo) {
+		drawBorder(
+			elementInfo.element,
+			landmarkName(elementInfo),
+			settings.borderColour,
+			labelFontColour,  // computed as a result of settings
+			settings.borderLabelFontSize)
 	}
 
 	// Create an element on the page to act as a border for the element to be
-	// highlighted, and a label for it.
-	//
-	// The format of the settings object is
-	//     { colour: #<hex>, fontColour: #<hex>, fontSize: <int> }
-	function addBorder(element, name, settings) {
+	// highlighted, and a label for it; position and style them appropriately
+	function drawBorder(element, label, colour, fontColour, fontSize) {
 		const zIndex = 10000000
-		const labelContent = document.createTextNode(name)
+		const labelContent = document.createTextNode(label)
 
 		const labelDiv = document.createElement('div')
-		labelDiv.style.backgroundColor = settings.colour
-		labelDiv.style.color = settings.fontColour
-		labelDiv.style.fontSize = settings.fontSize + 'px'
+		labelDiv.style.backgroundColor = colour
+		labelDiv.style.color = fontColour
+		labelDiv.style.fontSize = fontSize + 'px'
 		labelDiv.style.fontWeight = 'bold'
 		labelDiv.style.fontFamily = 'sans-serif'
 		labelDiv.style.float = 'right'
@@ -143,8 +161,8 @@ function ElementFocuser() {
 
 		const borderDiv = document.createElement('div')
 		sizeBorder(element, borderDiv)
-		borderDiv.style.border = '2px solid ' + settings.colour
-		borderDiv.style.outline = '2px solid ' + settings.colour
+		borderDiv.style.border = '2px solid ' + colour
+		borderDiv.style.outline = '2px solid ' + colour
 		borderDiv.style.position = 'absolute'
 		borderDiv.style.zIndex = zIndex
 		borderDiv.dataset.isLandmarkBorder = true
@@ -155,30 +173,52 @@ function ElementFocuser() {
 		document.body.appendChild(borderDiv)
 
 		currentlyFocusedElementBorder = borderDiv
-		currentResizeHandler = () => resize(element)
+		currentBorderResizeHandler = () => resize(element)
 
-		window.addEventListener('resize', currentResizeHandler)
+		window.addEventListener('resize', currentBorderResizeHandler)
 	}
 
-	// When the viewport changes, update the border <div>
+	// Given an element on the page and an element acting as the border, size
+	// the border appropriately for the element
+	function sizeBorder(element, border) {
+		const bounds = element.getBoundingClientRect()
+		border.style.left = window.scrollX + bounds.left + 'px'
+		border.style.top = window.scrollY + bounds.top + 'px'
+		border.style.width = bounds.width + 'px'
+		border.style.height = bounds.height + 'px'
+	}
+
+	// When the viewport changes, update the border <div>'s size
 	function resize(element) {
 		sizeBorder(element, currentlyFocusedElementBorder)
 	}
 
-	// When updating options, update the label font colour in line with the
-	// border colour and font size -- if a relevant option changed
-	function checkLabelFontColour(option) {
-		if (option === 'borderColour' || option === 'borderLabelFontSize') {
-			setLabelFontColour()
-		}
-	}
-
-	// Set the label font colour, based on existing settings (used when all
-	// settings have been retrieved at once)
-	function setLabelFontColour() {
+	// Work out if the label font colour should be black or white
+	function updateLabelFontColour() {
 		labelFontColour = contrastChecker.foregroundTextColour(
 			settings.borderColour,
 			settings.borderLabelFontSize,
 			true)  // the font is always bold
+	}
+
+	// Redraw an existing border
+	function redrawBorder() {
+		if (currentlyFocusedElementBorder) {
+			if (settings.borderType === 'persistent') {
+				removeBorderOnCurrentlySelectedElement()
+				addBorder(currentlyFocusedElementInfo)
+			}
+		}
+	}
+
+	// Should a border be added/removed?
+	function borderTypeChange() {
+		if (settings.borderType === 'persistent') {
+			if (currentlyFocusedElementInfo) {
+				addBorder(currentlyFocusedElementInfo)
+			}
+		} else {
+			removeBorderOnCurrentlySelectedElement()
+		}
 	}
 }

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -53,11 +53,6 @@ input[type=number] {
 			<label for="debug-info" data-message="prefsDebugInfo"></label>
 		</div>
 
-		<div>
-			<button id="save" data-message="prefsSaveButton" class="browser-style"></button>
-			<span role="alert" id="status"></span>
-		</div>
-
 		<script src="compatibility.js"></script>
 		<script src="defaults.js"></script>
 		<script src="options.js"></script>

--- a/src/static/options.js
+++ b/src/static/options.js
@@ -36,7 +36,6 @@ function restoreOptions() {
 	browser.storage.sync.get(defaultSettings, function(items) {
 		for (const option of options) {
 			option.element[option.property] = items[option.name]
-			console.log('Landmarks: restored', option.name, items[option.name])
 		}
 	})
 }
@@ -44,15 +43,11 @@ function restoreOptions() {
 function setUpOptionHandlers() {
 	for (const option of options) {
 		option.element.addEventListener('change', () => {
-			saveOption(option.name, option.element[option.property])
+			browser.storage.sync.set({
+				[option.name]: option.element[option.property]
+			})
 		})
 	}
-}
-
-function saveOption(option, datum) {
-	const save = { [option]: datum }
-	console.log('Landmarks: saving', save)
-	browser.storage.sync.set(save)  // no error handler
 }
 
 document.addEventListener('DOMContentLoaded', translateStuff)

--- a/src/static/options.js
+++ b/src/static/options.js
@@ -1,46 +1,26 @@
 'use strict'
 /* global defaultSettings */
-const statusMessageDuration = 2000
-const borderTypeId = 'border-type'
-const borderColourId = 'border-colour'
-const borderLabelFontSizeId = 'border-label-font-size'
-const debugInfoId = 'debug-info'
-
-function saveOptions() {
-	setWrapper({
-		borderType: document.getElementById(borderTypeId).value,
-		borderColour: document.getElementById(borderColourId).value,
-		borderLabelFontSize:
-			document.getElementById(borderLabelFontSizeId).value,
-		debugInfo: document.getElementById(debugInfoId).checked,
-	})
-}
-
-function restoreOptions() {
-	browser.storage.sync.get(defaultSettings, function(items) {
-		document.getElementById(borderTypeId).value = items.borderType
-		document.getElementById(borderColourId).value = items.borderColour
-		document.getElementById(borderLabelFontSizeId).value =
-			items.borderLabelFontSize
-		document.getElementById(debugInfoId).checked = items.debugInfo
-	})
-}
-
-// Wrapper to simplify saving settings, and handle the status update.
-function setWrapper(options) {
-	const area = browser.storage.sync
-	area.set(options, function() {
-		const statusRegion = document.getElementById('status')
-		statusRegion.textContent = browser.i18n.getMessage('prefsSaved')
-		setTimeout(function() {
-			statusRegion.textContent = ''
-		}, statusMessageDuration)
-	})
-}
+const options = [{
+	name: 'borderType',
+	element: document.getElementById('border-type'),
+	property: 'value'
+}, {
+	name: 'borderColour',
+	element: document.getElementById('border-colour'),
+	property: 'value'
+}, {
+	name: 'borderLabelFontSize',
+	element: document.getElementById('border-label-font-size'),
+	property: 'value'
+}, {
+	name: 'debugInfo',
+	element: document.getElementById('debug-info'),
+	property: 'checked'
+}]
 
 // Translation
-// Based on http://tumble.jeremyhubert.com/post/7076881720/translating-html-in-a-chrome-extension - HT http://stackoverflow.com/questions/25467009/
-// TODO probably will need DRYing in future
+// http://tumble.jeremyhubert.com/post/7076881720
+// HT http://stackoverflow.com/questions/25467009/
 // TODO would be nice to use the doForEach wrpper on this
 function translateStuff() {
 	const objects = document.getElementsByTagName('*')
@@ -52,6 +32,29 @@ function translateStuff() {
 	}
 }
 
+function restoreOptions() {
+	browser.storage.sync.get(defaultSettings, function(items) {
+		for (const option of options) {
+			option.element[option.property] = items[option.name]
+			console.log('Landmarks: restored', option.name, items[option.name])
+		}
+	})
+}
+
+function setUpOptionHandlers() {
+	for (const option of options) {
+		option.element.addEventListener('change', () => {
+			saveOption(option.name, option.element[option.property])
+		})
+	}
+}
+
+function saveOption(option, datum) {
+	const save = { [option]: datum }
+	console.log('Landmarks: saving', save)
+	browser.storage.sync.set(save)  // no error handler
+}
+
 document.addEventListener('DOMContentLoaded', translateStuff)
 document.addEventListener('DOMContentLoaded', restoreOptions)
-document.getElementById('save').addEventListener('click', saveOptions)
+document.addEventListener('DOMContentLoaded', setUpOptionHandlers)


### PR DESCRIPTION
This removes the need for the user to press the “Save” button to save options (and removes the button).

The borders will be redrawn/removed to reflect changing settings.

Closes #22