### PR TITLE
Specify unused relevant CSS; Remove data attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Changes
 -------
 
 -   2.3.0 - ??th of May 2018
-    -   Add landmark labels to the border, which is now drawn more robustly and has customisable colour. \[[\#158](https://github.com/matatk/landmarks/pull/158)\]
+    -   Add landmark labels to the border, which is now drawn more robustly and has customisable colour. \[[\#158](https://github.com/matatk/landmarks/pull/158), [\#162](https://github.com/matatk/landmarks/pull/162)\]
     -   Options are saved as they're changed by the user, and borders get updated to reflect settings changes immediately. \[[\#160](https://github.com/matatk/landmarks/pull/160)\]
     -   Minor tweaks to documentation; build process. \[[\#159](https://github.com/matatk/landmarks/pull/159), [\#161](https://github.com/matatk/landmarks/pull/161)\]
 -   2.2.0 - 18th of February 2018

--- a/src/static/content.focusing.js
+++ b/src/static/content.focusing.js
@@ -158,6 +158,9 @@ function ElementFocuser() {
 		labelDiv.style.paddingTop = '0.25em'
 		labelDiv.style.paddingBottom = '0.25em'
 		labelDiv.style.zIndex = zIndex
+		labelDiv.style.margin = '0'
+		labelDiv.style.border = 'none'
+		labelDiv.style.outline = 'none'
 
 		const borderDiv = document.createElement('div')
 		sizeBorder(element, borderDiv)
@@ -165,7 +168,9 @@ function ElementFocuser() {
 		borderDiv.style.outline = '2px solid ' + colour
 		borderDiv.style.position = 'absolute'
 		borderDiv.style.zIndex = zIndex
-		borderDiv.dataset.isLandmarkBorder = true
+		borderDiv.style.setProperty('margin', '0', '!important')
+		borderDiv.style.margin = '0'
+		borderDiv.style.padding = '0'
 
 		labelDiv.appendChild(labelContent)
 		borderDiv.appendChild(labelDiv)

--- a/src/static/content.focusing.js
+++ b/src/static/content.focusing.js
@@ -168,7 +168,6 @@ function ElementFocuser() {
 		borderDiv.style.outline = '2px solid ' + colour
 		borderDiv.style.position = 'absolute'
 		borderDiv.style.zIndex = zIndex
-		borderDiv.style.setProperty('margin', '0', '!important')
 		borderDiv.style.margin = '0'
 		borderDiv.style.padding = '0'
 


### PR DESCRIPTION
This resets various CSS properties that are not explicitly used by the
border and label elements, in case the page does set them. It also
removes a redundant data attribute that was used early on in #158 but a
better way was found to ignore the borders so it's no longer needed.