### PR TITLE
Fix for Firefox overflowing buttons on Windows

### DIFF
--- a/src/static/options.css
+++ b/src/static/options.css
@@ -1,0 +1,21 @@
+div.label-first {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	padding-bottom: 0.5em;
+}
+
+div.input-first {
+	padding-bottom: 0.5em;
+}
+
+div.label-first label {
+	grid-column: 1 / 2;
+}
+
+div.label-first input, div.label-first select {
+	grid-column: 2 / 3;
+}
+
+input[type=number] {
+	width: 3em;
+}

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -3,29 +3,7 @@
 	<head>
 		<meta charset="UTF-8">
 		<title data-message="prefsTitle"></title>
-		<style>
-div.label-first {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	padding-bottom: 0.5em;
-}
-
-div.input-first {
-	padding-bottom: 0.5em;
-}
-
-div.label-first label {
-	grid-column: 1 / 2;
-}
-
-div.label-first input, div.label-first select {
-	grid-column: 2 / 3;
-}
-
-input[type=number] {
-	width: 3em;
-}
-		</style>
+		<link rel="stylesheet" href="options.css">
 	</head>
 	<body>
 		<div class="label-first">

--- a/src/static/popup.css
+++ b/src/static/popup.css
@@ -13,6 +13,12 @@ li {
 
 button {
 	margin: 0.25em;
+	height: auto;         /* stops Firefox causing overflows on Windows
+	                         https://github.com/matatk/landmarks/issues/149 */
+	padding-left: 0.5em;  /* These are needed due to the above */
+	padding-right: 0.5em;
+	padding-top: 0.25em;
+	padding-bottom: 0.25em;
 }
 
 body {


### PR DESCRIPTION
* Add extra CSS to work around #149 - doesn"t fix the underlying problem
but closes #149. The underlying problem appears to be "height: 24px"
hardcoded into extension.css within Firefox.
* Move the CSS for the options page into a separate CSS file, to match
the popup.