### PR TITLE
Empty getElementById; Docs cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ This is a fork of the [original landmarks extension](https://github.com/davidtod
 Changes
 -------
 
--   2.3.1 - 1st of June 2018
-    -   Support multiple labelling elements when `aria-labelledby` is used. [\#176](https://github.com/matatk/landmarks/pull/176)
-    -   Small refinements to the build process and documentation. [\#174](https://github.com/matatk/landmarks/pull/174)
+-   2.3.1 - 3rd of June 2018
+    -   Support multiple labelling elements when `aria-labelledby` is used. \[[\#176](https://github.com/matatk/landmarks/pull/176)\]
+    -   Small refinements to the build process, documentation and error-handling. \[[\#174](https://github.com/matatk/landmarks/pull/174), [\#178](https://github.com/matatk/landmarks/pull/178)\]
 -   2.3.0 - 17th of May 2018
     -   Add landmark labels to the border, which is now drawn more robustly and has customisable colour. \[[\#158](https://github.com/matatk/landmarks/pull/158), [\#162](https://github.com/matatk/landmarks/pull/162)\]
     -   Options are saved as they're changed by the user, and borders get updated to reflect settings changes immediately. \[[\#160](https://github.com/matatk/landmarks/pull/160)\]

--- a/src/static/content.finder.js
+++ b/src/static/content.finder.js
@@ -174,10 +174,10 @@ function LandmarksFinder(win, doc) {
 	function getARIAProvidedLabel(element) {
 		let label = null
 
-		const labelIDs = element.getAttribute('aria-labelledby')
-		if (labelIDs !== null) {
-			const innerTexts = Array.from(labelIDs.split(' '), labelID => {
-				const labelElement = doc.getElementById(labelID)
+		const idRefs = element.getAttribute('aria-labelledby')
+		if (idRefs !== null && idRefs.length > 0) {
+			const innerTexts = Array.from(idRefs.split(' '), idRef => {
+				const labelElement = doc.getElementById(idRef)
 				return getInnerText(labelElement)
 			})
 			label = innerTexts.join(' ')


### PR DESCRIPTION
* Check for empty string under `aria-labelledby`.
* Docs formatting and release date tweaks.