### PR TITLE
Narrow regions; Split borders; Pointer events; Full-height/width regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ This is a fork of the [original landmarks extension](https://github.com/davidtod
 Changes
 -------
 
--   2.3.1 - 8th of June 2018
+-   2.3.1 - 9th of June 2018
     -   Support multiple labelling elements when `aria-labelledby` is used. \[[\#176](https://github.com/matatk/landmarks/pull/176)\]
     -   Keep labels legible, and borders neat, when landmark regions are narrow, or full-width/height. Also let pointer events through the border so the user can interact as normal with the page below. \[[\#179](https://github.com/matatk/landmarks/pull/179)\]
     -   Small refinements to the build process, documentation and error-handling. \[[\#174](https://github.com/matatk/landmarks/pull/174), [\#178](https://github.com/matatk/landmarks/pull/178)\]

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Changes
 
 -   2.3.1 - 3rd of June 2018
     -   Support multiple labelling elements when `aria-labelledby` is used. \[[\#176](https://github.com/matatk/landmarks/pull/176)\]
+    -   Keep labels legible, and borders neat, when landmark regions are narrow. \[[\#179](https://github.com/matatk/landmarks/pull/179)\]
     -   Small refinements to the build process, documentation and error-handling. \[[\#174](https://github.com/matatk/landmarks/pull/174), [\#178](https://github.com/matatk/landmarks/pull/178)\]
 -   2.3.0 - 17th of May 2018
     -   Add landmark labels to the border, which is now drawn more robustly and has customisable colour. \[[\#158](https://github.com/matatk/landmarks/pull/158), [\#162](https://github.com/matatk/landmarks/pull/162)\]

--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ This is a fork of the [original landmarks extension](https://github.com/davidtod
 Changes
 -------
 
--   2.3.1 - 3rd of June 2018
+-   2.3.1 - 8th of June 2018
     -   Support multiple labelling elements when `aria-labelledby` is used. \[[\#176](https://github.com/matatk/landmarks/pull/176)\]
-    -   Keep labels legible, and borders neat, when landmark regions are narrow. \[[\#179](https://github.com/matatk/landmarks/pull/179)\]
+    -   Keep labels legible, and borders neat, when landmark regions are narrow, or full-width/height. Also let pointer events through the border so the user can interact as normal with the page below. \[[\#179](https://github.com/matatk/landmarks/pull/179)\]
     -   Small refinements to the build process, documentation and error-handling. \[[\#174](https://github.com/matatk/landmarks/pull/174), [\#178](https://github.com/matatk/landmarks/pull/178)\]
 -   2.3.0 - 17th of May 2018
     -   Add landmark labels to the border, which is now drawn more robustly and has customisable colour. \[[\#158](https://github.com/matatk/landmarks/pull/158), [\#162](https://github.com/matatk/landmarks/pull/162)\]

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.0.tgz",
-      "integrity": "sha512-hWzNviaVFIr1TqcRA8ou49JaSHp+Rfabmnqg2kNvusKqLhPU0rIsGPUj5WJJ7ld4Bb7qdgLmIhLfCD1qS08IVA==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.2.tgz",
+      "integrity": "sha512-9NfEUDp3tgRhmoxzTpTo+lq+KIVFxZahuRX0LHF/9IzKHaWuoWsIrrJ61zw5cnnlGINX8lqJzXYfQTOICS5Q+A==",
       "dev": true
     },
     "abab": {
@@ -23,9 +23,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.1.tgz",
-      "integrity": "sha512-XH4o5BK5jmw9PzSGK7mNf+/xV+mPxQxGZoeC36OVsJZYV77JAG9NnI7T90hoUpI/C1TOfXWTvugRdZ9ZR3iE2Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
+      "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
       "dev": true
     },
     "acorn-globals": {
@@ -2338,12 +2338,12 @@
       }
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -2866,9 +2866,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -3524,9 +3524,9 @@
       "dev": true
     },
     "nwsapi": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.1.tgz",
-      "integrity": "sha512-xOJJb7kAAGy6UOklbaIPA0iu/27VMHfAbMUgYJlXz4qRXytIkPGM2vwfbxa+tbaqcqHNsP6RN4eDZlePelWKpQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.2.tgz",
+      "integrity": "sha512-wAvMV1QgoYPvqfcAmX1M86SyZA3SnNT6UNvjqO/pKHjIZzhMpPHjCTOWdOfkmUknjnvjDq09wDiBaHAzXSLiSA==",
       "dev": true
     },
     "oauth-sign": {
@@ -3663,9 +3663,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
         "p-try": "^1.0.0"
@@ -4068,19 +4068,19 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.4.0.tgz",
-      "integrity": "sha512-WDnC1FSHTedvRSS8BZB73tPAx2svUCWFdcxVjrybw8pbKOAB1v5S/pW0EamkqQoL1mXiBc+v8lyYjhhzMHIk1Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.5.0.tgz",
+      "integrity": "sha512-eELwFtFxL+uhmg4jPZOZXzSrPEYy4CaYQNbcchBbfxY+KjMpnv6XGf/aYWaQG49OTpfi2/DMziXtDM8XuJgoUA==",
       "dev": true,
       "requires": {
         "debug": "^3.1.0",
-        "extract-zip": "^1.6.5",
-        "https-proxy-agent": "^2.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
         "mime": "^2.0.3",
         "progress": "^2.0.0",
         "proxy-from-env": "^1.0.0",
         "rimraf": "^2.6.1",
-        "ws": "^3.0.0"
+        "ws": "^5.1.1"
       },
       "dependencies": {
         "debug": {
@@ -4093,14 +4093,12 @@
           }
         },
         "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.0.tgz",
+          "integrity": "sha512-c18dMeW+PEQdDFzkhDsnBAlS4Z8KGStBQQUcQ5mf7Nf689jyGk0594L+i9RaQuf4gog6SvWLJorz2NfSaqxZ7w==",
           "dev": true,
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -4625,9 +4623,9 @@
       }
     },
     "snyk": {
-      "version": "1.82.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.82.0.tgz",
-      "integrity": "sha512-UZuGBdh3PSK6Va9Sos+hFUnLImIShluHfOSvF3UdM0jmjOaIRvIywkUrqT7J38xQ0VRmbVCoJlrYA1g7vD1CeA==",
+      "version": "1.82.1",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.82.1.tgz",
+      "integrity": "sha1-3wq/nTmFB7US4nSXkNpn5Ww6hT4=",
       "dev": true,
       "requires": {
         "abbrev": "^1.1.1",
@@ -5014,9 +5012,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -5026,6 +5024,7 @@
         "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
         "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
     },
@@ -5516,12 +5515,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-      "dev": true
-    },
     "undefsafe": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.2.tgz",
@@ -5637,20 +5630,12 @@
       }
     },
     "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        }
+        "inherits": "2.0.3"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "husky": "~0.14",
     "jsdom": "~11.11",
     "one-svg-to-many-sized-pngs": "github:matatk/one-svg-to-many-sized-pngs#0.1.1",
-    "puppeteer": "~1.4",
+    "puppeteer": "~1.5",
     "replace-in-file": "~3.4",
     "rimraf": "~2.6",
     "test": "~0.6"

--- a/src/static/content.focusing.js
+++ b/src/static/content.focusing.js
@@ -165,6 +165,7 @@ function ElementFocuser() {
 		labelDiv.style.backgroundColor = colour
 		labelDiv.style.border = 'none'
 		labelDiv.style.color = fontColour
+		labelDiv.style.display = 'inline-block'
 		labelDiv.style.fontFamily = 'sans-serif'
 		labelDiv.style.fontSize = fontSize + 'px'
 		labelDiv.style.fontWeight = 'bold'
@@ -175,6 +176,7 @@ function ElementFocuser() {
 		labelDiv.style.paddingRight = '0.75em'
 		labelDiv.style.paddingTop = '0.25em'
 		labelDiv.style.position = 'absolute'
+		labelDiv.style.whiteSpace = 'nowrap'
 		labelDiv.style.zIndex = zIndex
 
 		labelDiv.appendChild(labelContent)
@@ -192,8 +194,9 @@ function ElementFocuser() {
 		window.addEventListener('resize', currentBorderResizeHandler)
 	}
 
-	// Given an element on the page and an element acting as the border, size
-	// the border appropriately for the element
+	// Given an element on the page and elements acting as the border and
+	// label, size the border, and position the label, appropriately for the
+	// element
 	function sizeBorder(element, border, label) {
 		const elementBounds = element.getBoundingClientRect()
 
@@ -211,12 +214,20 @@ function ElementFocuser() {
 		border.style.width = elementBounds.width + 'px'
 		border.style.height = elementBounds.height + 'px'
 
+		// Try aligning the right edge of the label to the right edge of the
+		// border.
+		//
+		// If the label is too wide, align the left edge of the label to the
+		// left edge of the border.
+
+		label.style.removeProperty('left')  // in case this was set before
+
 		label.style.top = elementTopEdgePx - borderWidthPx + 'px'
 		label.style.right = elementRightEdgeStyle
 
 		// Is part of the label off-screen?
 		const labelBounds = label.getBoundingClientRect()
-		if (labelBounds.left < 0) {
+		if (labelBounds.left < 0 || label.scrollWidth > label.offsetWidth) {
 			label.style.removeProperty('right')
 			label.style.left = elementLeftEdgeStyle
 		}

--- a/src/static/content.focusing.js
+++ b/src/static/content.focusing.js
@@ -164,6 +164,8 @@ function ElementFocuser() {
 		borderDiv.style.margin = '0'
 		borderDiv.style.outline = outlineWidthPx + 'px solid ' + colour
 		borderDiv.style.padding = '0'
+		// Pass events through - https://stackoverflow.com/a/6441884/1485308
+		borderDiv.style.pointerEvents = 'none'
 		borderDiv.style.position = 'absolute'
 		borderDiv.style.zIndex = zIndex
 

--- a/src/static/content.focusing.js
+++ b/src/static/content.focusing.js
@@ -195,23 +195,30 @@ function ElementFocuser() {
 	// Given an element on the page and an element acting as the border, size
 	// the border appropriately for the element
 	function sizeBorder(element, border, label) {
-		const bounds = element.getBoundingClientRect()
+		const elementBounds = element.getBoundingClientRect()
 
-		border.style.left = window.scrollX + bounds.left + 'px'
-		border.style.top = window.scrollY + bounds.top + 'px'
-		border.style.width = bounds.width + 'px'
-		border.style.height = bounds.height + 'px'
+		const elementTopEdgePx = window.scrollY + elementBounds.top
 
-		// TODO test on side-scrolling page
-		label.style.top = window.scrollY + bounds.top - borderWidthPx + 'px'
-		label.style.right =
-			(window.innerWidth -
-				(window.scrollX + bounds.right + 2 * borderWidthPx)) + 'px'
+		const elementLeftEdgeStyle = window.scrollX + elementBounds.left + 'px'
+
+		const elementRightEdgeStyle =
+			window.innerWidth
+			- (window.scrollX + elementBounds.right + 2 * borderWidthPx)
+			+ 'px'
+
+		border.style.left = elementLeftEdgeStyle
+		border.style.top = elementTopEdgePx + 'px'
+		border.style.width = elementBounds.width + 'px'
+		border.style.height = elementBounds.height + 'px'
+
+		label.style.top = elementTopEdgePx - borderWidthPx + 'px'
+		label.style.right = elementRightEdgeStyle
 
 		// Is part of the label off-screen?
 		const labelBounds = label.getBoundingClientRect()
-		if (labelBounds.left < 0) {  // TODO test on side-scrolling page
+		if (labelBounds.left < 0) {
 			label.style.removeProperty('right')
+			label.style.left = elementLeftEdgeStyle
 		}
 
 		justMadeChanges = true  // TODO seems to be in the right place

--- a/src/static/content.focusing.js
+++ b/src/static/content.focusing.js
@@ -208,8 +208,8 @@ function ElementFocuser() {
 		const elementBounds = element.getBoundingClientRect()
 		const elementTopEdgeStyle = window.scrollY + elementBounds.top + 'px'
 		const elementLeftEdgeStyle = window.scrollX + elementBounds.left + 'px'
-		const elementRightEdgeStyle =
-			window.innerWidth - (window.scrollX + elementBounds.right) + 'px'
+		const elementRightEdgeStyle = document.documentElement.clientWidth -
+			(window.scrollX + elementBounds.right) + 'px'
 
 		border.style.left = elementLeftEdgeStyle
 		border.style.top = elementTopEdgeStyle

--- a/src/static/content.focusing.js
+++ b/src/static/content.focusing.js
@@ -6,8 +6,7 @@ function ElementFocuser() {
 	const contrastChecker = new ContrastChecker()
 
 	const momentaryBorderTime = 2000
-	const borderWidthPx = 2
-	const outlineWidthPx = 2
+	const borderWidthPx = 4
 
 	const settings = {}         // caches options locally (simpler drawing code)
 	let labelFontColour = null  // computed based on border colour
@@ -161,8 +160,8 @@ function ElementFocuser() {
 
 		const borderDiv = document.createElement('div')
 		borderDiv.style.border = borderWidthPx + 'px solid ' + colour
+		borderDiv.style.boxSizing = 'border-box'
 		borderDiv.style.margin = '0'
-		borderDiv.style.outline = outlineWidthPx + 'px solid ' + colour
 		borderDiv.style.padding = '0'
 		// Pass events through - https://stackoverflow.com/a/6441884/1485308
 		borderDiv.style.pointerEvents = 'none'
@@ -172,13 +171,13 @@ function ElementFocuser() {
 		const labelDiv = document.createElement('div')
 		labelDiv.style.backgroundColor = colour
 		labelDiv.style.border = 'none'
+		labelDiv.style.boxSizing = 'border-box'
 		labelDiv.style.color = fontColour
 		labelDiv.style.display = 'inline-block'
 		labelDiv.style.fontFamily = 'sans-serif'
 		labelDiv.style.fontSize = fontSize + 'px'
 		labelDiv.style.fontWeight = 'bold'
 		labelDiv.style.margin = '0'
-		labelDiv.style.outline = 'none'
 		labelDiv.style.paddingBottom = '0.25em'
 		labelDiv.style.paddingLeft = '0.75em'
 		labelDiv.style.paddingRight = '0.75em'
@@ -207,15 +206,13 @@ function ElementFocuser() {
 	// element
 	function sizeBorderAndLabel(element, border, label) {
 		const elementBounds = element.getBoundingClientRect()
-		const elementTopEdgePx = window.scrollY + elementBounds.top
+		const elementTopEdgeStyle = window.scrollY + elementBounds.top + 'px'
 		const elementLeftEdgeStyle = window.scrollX + elementBounds.left + 'px'
 		const elementRightEdgeStyle =
-			window.innerWidth
-			- (window.scrollX + elementBounds.right + 2 * borderWidthPx)
-			+ 'px'
+			window.innerWidth - (window.scrollX + elementBounds.right) + 'px'
 
 		border.style.left = elementLeftEdgeStyle
-		border.style.top = elementTopEdgePx + 'px'
+		border.style.top = elementTopEdgeStyle
 		border.style.width = elementBounds.width + 'px'
 		border.style.height = elementBounds.height + 'px'
 
@@ -227,7 +224,7 @@ function ElementFocuser() {
 
 		label.style.removeProperty('left')  // in case this was set before
 
-		label.style.top = elementTopEdgePx - borderWidthPx + 'px'
+		label.style.top = elementTopEdgeStyle
 		label.style.right = elementRightEdgeStyle
 
 		// Is part of the label off-screen?

--- a/test/fixtures/digital-publishing-roles.html
+++ b/test/fixtures/digital-publishing-roles.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-GB">
+<html lang="en">
 	<head>
 		<meta charset="UTF-8">
 		<title>Example Book</title>

--- a/test/manual-test-full-height-regions.html
+++ b/test/manual-test-full-height-regions.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>Full-height regions</title>
+		<style>
+html, body {
+	height: 100%;
+	width: 100%;
+	margin: 0;
+	padding: 0;
+}
+
+nav {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 4em;
+	background-color: #ffa;
+}
+
+main {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	display: block;
+	background-color: #afa;
+}
+
+aside {
+	position: absolute;
+	top: 0;
+	left: 0;
+	height: 100%;
+	width: 4em;
+	background-color: #aff;
+}
+		</style>
+	</head>
+	<body>
+		<main aria-label="Tall and Wide"></main>
+		<nav aria-label="Wide"></nav>
+		<aside aria-label="Tall"></aside>
+	</body>
+</html>

--- a/test/manual-test-injected-landmarks.html
+++ b/test/manual-test-injected-landmarks.html
@@ -2,21 +2,21 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8">
-		<title>Test injected landmark</title>
+		<title>Test injected landmarks</title>
 	</head>
 	<body>
 		<header>
-			<h1>Test injected landmark</h1>
+			<h1>Test injected landmarks</h1>
 		</header>
 		<main>
-		<p>Main content.</p>
-		<button id="outer-injector">Inject a landmark</button>
-		<button id="inner-injector" disabled>
-			Inject a landmark inside the other
-		</button>
-		<button id="the-cleaner" disabled>
-			Remove all injected bits and bobs
-		</button>
+			<p>Main content.</p>
+			<button id="outer-injector">Inject a landmark</button>
+			<button id="inner-injector" disabled>
+				Inject a landmark inside the other
+			</button>
+			<button id="the-cleaner" disabled>
+				Remove all injected bits and bobs
+			</button>
 		</main>
 		<footer>
 			<p>This is the footer.</p>

--- a/test/manual-test-narrow-regions.html
+++ b/test/manual-test-narrow-regions.html
@@ -24,7 +24,7 @@ header, nav, main, aside, footer {
 }
 
 nav {
-	width: 4vw;
+	width: 25vw;
 }
 
 main {
@@ -34,7 +34,7 @@ main {
 }
 
 aside {
-	width: 4vw;
+	width: 5vw;
 }
 		</style>
 	</head>
@@ -47,7 +47,7 @@ aside {
 				nav
 			</nav>
 			<main>
-				main
+				Focus the "nav" region and resize the viewport; the label will switch to being anchored to the left side of the border (instead of the right) at the point that it would've gone off-screen to the left.
 			</main>
 			<aside aria-label="Another overly verbose handle">
 				aside

--- a/test/manual-test-narrow-regions.html
+++ b/test/manual-test-narrow-regions.html
@@ -4,9 +4,15 @@
 		<meta charset="utf-8">
 		<title>Narrow regions and side-scrolling test</title>
 		<style>
+html, body {
+	height: 100%;
+	margin: 0;
+	padding: 0;
+}
+
 header, nav, main, aside, footer {
 	border: 2px solid black;
-	margin-bottom: 0.5em;
+	margin-top: 0.5em;
 	padding: 0.5em;
 }
 
@@ -16,7 +22,11 @@ header, nav, main, aside, footer {
 
 .page {
 	flex-direction: column;
-	height: 95vh;
+	height: 100%;
+	box-sizing: border-box;
+	padding-left: 0.5em;
+	padding-right: 0.5em;
+	padding-bottom: 0.5em;
 }
 
 .content {

--- a/test/manual-test-narrow-regions.html
+++ b/test/manual-test-narrow-regions.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8">
-		<title>Narrow regions test</title>
+		<title>Narrow regions and side-scrolling test</title>
 		<style>
 header, nav, main, aside, footer {
 	border: 2px solid black;
@@ -20,7 +20,9 @@ header, nav, main, aside, footer {
 }
 
 .content {
+	width: 100vw;
 	flex-grow: 1;
+	margin-left: 50vw;
 }
 
 nav {
@@ -40,7 +42,7 @@ aside {
 	</head>
 	<body class="container page">
 		<header>
-			<h1>Narrow regions test</h1>
+			<h1>Narrow regions and side-scrolling test</h1>
 		</header>
 		<div class="container content">
 			<nav aria-label="Really long-winded name">
@@ -49,7 +51,7 @@ aside {
 			<main>
 				Focus the "nav" region and resize the viewport; the label will switch to being anchored to the left side of the border (instead of the right) at the point that it would've gone off-screen to the left.
 			</main>
-			<aside aria-label="Another overly verbose handle">
+			<aside aria-label="Another overly-verbose handle">
 				aside
 			</aside>
 		</div>

--- a/test/manual-test-narrow-regions.html
+++ b/test/manual-test-narrow-regions.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="utf-8">
+		<meta charset="UTF-8">
 		<title>Narrow regions and side-scrolling test</title>
 		<style>
 html, body {

--- a/test/manual-test-narrow-regions.html
+++ b/test/manual-test-narrow-regions.html
@@ -49,7 +49,7 @@ aside {
 				nav
 			</nav>
 			<main>
-				Focus the "nav" region and resize the viewport; the label will switch to being anchored to the left side of the border (instead of the right) at the point that it would've gone off-screen to the left.
+				Move through the landmarks in this document, then go backwards after passing the "nav" region; the label will be drawn so that it doesn't go off-screen left. This can also be triggered on viewport resize.
 			</main>
 			<aside aria-label="Another overly-verbose handle">
 				aside

--- a/test/manual-test-narrow-regions.html
+++ b/test/manual-test-narrow-regions.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>Narrow regions test</title>
+		<style>
+header, nav, main, aside, footer {
+	border: 2px solid black;
+	margin-bottom: 0.5em;
+	padding: 0.5em;
+}
+
+.container {
+	display: flex;
+}
+
+.page {
+	flex-direction: column;
+	height: 95vh;
+}
+
+.content {
+	flex-grow: 1;
+}
+
+nav {
+	width: 4vw;
+}
+
+main {
+	flex-grow: 1;
+	margin-left: 0.5em;
+	margin-right: 0.5em;
+}
+
+aside {
+	width: 4vw;
+}
+		</style>
+	</head>
+	<body class="container page">
+		<header>
+			<h1>Narrow regions test</h1>
+		</header>
+		<div class="container content">
+			<nav aria-label="Really long-winded name">
+				nav
+			</nav>
+			<main>
+				main
+			</main>
+			<aside aria-label="Another overly verbose handle">
+				aside
+			</aside>
+		</div>
+		<footer>
+			footer
+		</footer>
+	</body>
+</html>

--- a/test/manual-test-tall-and-wide-regions.html
+++ b/test/manual-test-tall-and-wide-regions.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="utf-8">
-		<title>Full-height regions</title>
+		<meta charset="UTF-8">
+		<title>Tall and wide regions</title>
 		<style>
 html, body {
 	height: 100%;


### PR DESCRIPTION
This moves labels if need be to ensure they’re always visible. It also decouples the label from the border, to enable that re-positioning and to stop the “split borders” effect.

This also allows pointer events (such as mouse hover) to pass through the landmark border `<div>` so that the user can interact with the web page as normal.

Borders are drawn inside the space required by elements, to avoid introducing scrollbars when full-width/height regions are present.

Fixes #166
Fixes #175
Fixes #167 