### PR TITLE
Reflect document changes in elementFocuser

### DIFF
--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -6,7 +6,7 @@ import Logger from './logger'
 
 const logger = new Logger()
 const lf = new LandmarksFinder(window, document)
-const ef = new ElementFocuser()
+const ef = new ElementFocuser(document)
 const ph = new PauseHandler(logger)
 
 const outOfDateTime = 2000
@@ -93,6 +93,7 @@ function checkFocusElement(callbackReturningElementInfo) {
 function findLandmarksAndUpdateBackgroundScript() {
 	lf.find()
 	port.postMessage({ name: 'landmarks', data: lf.filter() })
+	ef.checkFocusedElement()
 }
 
 
@@ -139,7 +140,7 @@ function setUpMutationObserver() {
 		// Guard against being innundated by mutation events
 		// (which happens in e.g. Google Docs)
 		ph.run(
-			ef.didJustMakeChanges,
+			ef.didJustMakeChanges,  // ignore mutations if Landmarks caused them
 			function() {
 				if (shouldRefreshLandmarkss(mutations)) {
 					logger.log('Scan due to mutation')
@@ -197,8 +198,8 @@ if (BROWSER === 'firefox') {
 	// the user has moved away, but that haven't actually been destroyed yet.
 	// Thanks https://bugzilla.mozilla.org/show_bug.cgi?id=1390715
 	//
-	// Unfortunately that doesn't work for me; when it doesn't work, the
-	// content script never recieves this event in order to tell it to reload
+	// Unfortunately that doesn't work here; when it doesn't work, the
+	// content script never receives this event in order to tell it to reload
 	// the script.
 	/* window.addEventListener('pageshow', function(event) {
 		if (event.target !== window.document) return

--- a/src/code/elementFocuser.js
+++ b/src/code/elementFocuser.js
@@ -2,7 +2,7 @@ import landmarkName from './landmarkName'
 import { defaultBorderSettings } from './defaults'
 import ContrastChecker from './contrastChecker'
 
-export default function ElementFocuser() {
+export default function ElementFocuser(doc) {
 	const contrastChecker = new ContrastChecker()
 
 	const momentaryBorderTime = 2000
@@ -133,6 +133,19 @@ export default function ElementFocuser() {
 		const didChanges = justMadeChanges
 		justMadeChanges = false
 		return didChanges
+	}
+
+	// When the document is changed, the currently-focused element may have
+	// been removed, or at least changed size/position
+	this.checkFocusedElement = function() {
+		if (currentlyFocusedElementInfo) {
+			if (!doc.body.contains(currentlyFocusedElementInfo.element)) {
+				currentlyFocusedElementInfo = null  // can't resize anymore
+				removeBorderOnCurrentlySelectedElement()
+			} else {
+				currentResizeHandler()
+			}
+		}
 	}
 
 

--- a/src/code/landmarksFinder.js
+++ b/src/code/landmarksFinder.js
@@ -81,6 +81,7 @@ export default function LandmarksFinder(win, doc) {
 	//   role: (string)          -- the ARIA role
 	//   label: (string or null) -- author-supplied label
 	//   element: (HTML*Element) -- in-memory element
+	//   selector: (string)      -- CSS selector path for this element
 
 
 	//

--- a/src/code/pauseHandler.js
+++ b/src/code/pauseHandler.js
@@ -62,7 +62,10 @@ export default function PauseHandler(logger) {
 	//
 
 	this.run = function(ignoreCheck, guardedTask, scheduledTask) {
-		if (ignoreCheck()) return
+		if (ignoreCheck()) {
+			logger.log('pH: ignoring changes')
+			return
+		}
 
 		const now = Date.now()
 		if (now > lastEvent + pause) {
@@ -70,9 +73,9 @@ export default function PauseHandler(logger) {
 			lastEvent = now
 		} else if (!haveIncreasedPauseAndScheduledTask) {
 			increasePause()
-			logger.log('Scheduling scan in:', pause)
+			logger.log('pH: scheduling task in:', pause)
 			setTimeout(() => {
-				logger.log('Scan as scheduled')
+				logger.log('pH: running task as scheduled')
 				scheduledTask()
 				decreasePause()
 				haveIncreasedPauseAndScheduledTask = false


### PR DESCRIPTION
* If a mutation removes an element from the DOM, remove the border
(fixes #208).
* Otherwise, a mutation may move/resize an element, so update the border
(this could possibly be made more efficient by checking if the resize is
needed, should profile in future).
* Update documentation for landmarks[] structure in landmarksFinder.
* Clarify log messages from pauseHandler.
* Tidy up some comments in _content.