### PR TITLE
Fix file missing from zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ This is a fork of the [original landmarks extension](https://github.com/davidtod
 Changes
 -------
 
+-   2.4.1 - 28th of October 2018
+    -   Fix a bug with packaging that was causing the DevTools panel script to be left out of the zip file that gets uploaded to the browser add-on sites (oops again ;-)). \[[\#212](https://github.com/matatk/landmarks/pull/212)\]
 -   2.4.0 - 28th of October 2018
     -   Offer an optional sidebar as well as the toolbar pop-up on Firefox and Opera. \[[\#188](https://github.com/matatk/landmarks/pull/188), [\#199](https://github.com/matatk/landmarks/pull/199)\]
     -   Provide a Developer Tools panel that allows landmark elements to be inspected in the DOM viewer. This also entailed re-writing the internal communications between parts of Landmarks to use ports instead of one-time messages. \[[\#204](https://github.com/matatk/landmarks/pull/204)\]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "landmarks",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landmarks",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "scripts": {
     "pre_build": "npm test",


### PR DESCRIPTION
The changes in 3417085160ac9115362af4054eb03d6f6aa008a9 borked things in
an odd way: devtoolsPanel.js was missing from the created zip files.

Initially I tried fixing things by restoring the natural async behaviour
of the zip creation and linting only after the zip has made. Output from
the build script is not as neat.

This does make one change to how archiver is used: it passes false
instead of an empty string as the path under which the build directory
tree is to be added to the zip file. This is in line with the latest
archiver README.

That alone didn't actually solve things. I then changed the rollup code
to use await rather than promises for writing the bundle (as per the
current code examples on the rollup site). Now it's working again.

Decided not to try going back to the previous archiver code, as not
really sure if what I was doing regarding the handling of promises was
right (didn't seem great, mixed in with async/await).