### PR TITLE
Fix sidebar options

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ This is a fork of the [original landmarks extension](https://github.com/davidtod
 Changes
 -------
 
+-   2.4.2 - 29th of October 2018
+    -   Fix a bug with sidebar option initialisation. \[[\#213](https://github.com/matatk/landmarks/pull/213)\]
 -   2.4.1 - 28th of October 2018
     -   Fix a bug with packaging that was causing the DevTools panel script to be left out of the zip file that gets uploaded to the browser add-on sites (oops again ;-)). \[[\#212](https://github.com/matatk/landmarks/pull/212)\]
 -   2.4.0 - 28th of October 2018

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "landmarks",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landmarks",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": true,
   "scripts": {
     "pre_build": "npm test",

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -20,12 +20,12 @@ const options = [{
 }]
 
 if (BROWSER === 'firefox' || BROWSER === 'opera') {
-	options.push([{
+	options.push({
 		name: 'interface',
 		element: document.getElementById('landmarks-interface'),
 		property: 'value',
 		change: interfaceExplainer
-	}])
+	})
 }
 
 // Translation


### PR DESCRIPTION
An array (rather than object) was being pushed (introduced in
4e3cf798404b641eeac8541e8f59f2b2274b57bf), which was causing the sidebar
options to not be correctly registered, thus they would have no effect.

Need to improve the rigour of my QA process :-).