### PR TITLE
Improve appearance of DevTools panel on Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Changes
 -------
 
 -   2.4.3 - in development
+    -   Improve the appearance of the DevTools panel on Firefox. \[[\#217](https://github.com/matatk/landmarks/pull/217)\]
     -   Fix a bug whereby landmark updates for background tabs pages would show up in the pop-up if it's open. \[[\#216](https://github.com/matatk/landmarks/pull/216)\]
 -   2.4.2 - 29th of October 2018
     -   Fix a bug with sidebar option initialisation. \[[\#213](https://github.com/matatk/landmarks/pull/213)\]

--- a/src/static/gui.css
+++ b/src/static/gui.css
@@ -23,6 +23,7 @@ button {
 
 body {
 	padding: 0.5em;
+	font-family: sans-serif;
 }
 
 h1 {


### PR DESCRIPTION
It would have been somewhat complicated to use browser styles (both cross-browser, but mainly cross-OS, due to the extra Mac stylesheet that Firefox uses) and the GUI will be redesigned soon, so instead the DevTools panel was just asked to use sans serif fonts, which is simple and works nicely.

Closes #215.