### PR TITLE
feat: Enhanced help documentation, bundled with the extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.swp
 node_modules
 build
-_site
 meta/out-*.png
 landmarks-*.zip
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -7,83 +7,30 @@ This is a browser extension (for Firefox, Chrome and Opera) that enables navigat
 
 Landmark regions broadly signpost the areas of a page (e.g. navigation, search, main content and so on). They can make navigation considerably easier for people who use the keyboard to navigate and those using assistive technologies such as screen-readers, because they make it much quicker to get an overview and to navigate to (and between) areas of interest.
 
-The following sections explain how to install and use the extension.
-
 If you're a web author/developer, check out the information below on [why landmarks rock, and how easy they are to put into your site](#information-for-web-authors-designers-and-developers)&mdash;in fact, if you're using HTML 5, you probably already have landmarks on your site, but there are some ways to make them even more helpful, as discussed below.
 
 Table of Contents
 -----------------
 
--   [Installation](#installation)
--   [Navigating Landmarks](#navigating-landmarks)
--   [Border Preferences](#border-preferences)
+-   [Installation and usage](#installation-and-usage)
 -   [This Extension's Support for Landmarks](#this-extensions-support-for-landmarks)
 -   [Information for Web Authors, Designers and Developers](#information-for-web-authors-designers-and-developers)
 -   [Development](#development)
 -   [Acknowledgements](#acknowledgements)
 
-Installation
-------------
+Installation and usage
+----------------------
 
--   **Firefox:** [Install via Mozilla Add-ons](https://addons.mozilla.org/addon/landmarks/)
--   **Chrome:** [Install via the Chrome Web Store](https://chrome.google.com/webstore/detail/landmark-navigation-via-k/ddpokpbjopmeeiiolheejjpkonlkklgp)
--   **Opera:** [Install via Opera add-ons](https://addons.opera.com/en-gb/extensions/details/landmarks/)
+Use the [installation links on the home page](http://matatk.agrip.org.uk/landmarks/) to install the extension. When it's installed, you will find documentation on topics such as:
+
+* How to navigate by shortcut key, and how to change the shortcut keys.
+* How to navigate using the toolbar pop-up.
+* How to navigate using the sidebar (where supported).
+* Border preferences, for landmark highlights and labels whilst navigating.
 
 **If you need support, please [check the known issues for Landmarks](https://github.com/matatk/landmarks/issues) and, if necessary, file a new issue using the "New Issue" button on that page.**
 
-Navigating Landmarks
---------------------
-
-### Via Shortcut Key
-
-You can use shortcut keys to navigate between landmarks. By default, the keys are:
-
--   **Next landmark:** <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd>
--   **Previous landmark:** <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>
--   **Main landmark:** <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd>
--   **Open the landmarks pop-up:** <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd>, then use <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> to move between buttons, <kbd>Space</kbd> or <kbd>Enter</kbd> to move focus to a landmark and <kbd>Escape</kbd> to close the pop-up.
-
-(On a Mac, use the <kbd>Option</kbd> key, which is equivalent to <kbd>Alt</kbd>.)
-
-Landmarks will be focused, and a border shown according to your [border preferences](#border-preferences).
-
-You can change the keyboard shortcuts in the following browsers.
-
--   **Chrome:** More ⋮ → Settings → Extensions \[on the left-hand side\] → Keyboard shortcuts \[at the bottom of the page\]
--   **Opera:** Opera Menu / Speed Dial → Extensions → Extension Keyboard Shortcuts
-
-### Via Toolbar Pop-up
-
-If landmarks are found on the page, the Landmarks button in the toolbar (which looks like an "L") will be badged with the number of landmarks found.
-
-1.  Activate the Landmarks toolbar button. A pop-up will appear. If landmarks are present on the page, they will be shown in a nested list, reflecting the structure of the landmarks on the page.
-
-2.  Activate a button in the list to move to that landmark. The landmark will be focused, and a border shown according to your [border preferences](#border-preferences).
-
-3.  To close the pop-up, press <kbd>Escape</kbd>, or click outside of the pop-up.
-
-### Inspecting landmarks in the DOM
-
-A Developer Tools panel called "Landmarks" is also provided. This can be used in the same way as the pop-up above, but also allows you to visit each landmark element in the DOM inspector, using inspection buttons that are placed immediately after the button for each landmark.
-
-This feature is primarily intended for web authors/developers and accessibility testers.
-
-Border Preferences
-------------------
-
-A border will be drawn around the landmarks as you navigate them. The border contains a label that displays the landmark's type and name (if one was provided by the author of the page). You can customise various aspects of this in the extension's preferences/options page. The available settings are:
-
--   **If the border should be displayed, and for how long.**
-    -   **Momentary (default):** the border remains visible for a short time, then disappears.
-    -   **Persistent:** the border remains visible at all times.
-    -   **None:** no border is drawn.
--   **The border's colour.**
--   **The font size used in the landmark label.**
-
-You can get to the extension's settings as follows.
-
--   **Firefox:** Menu ☰ → Add-ons → Extensions \[on left-hand side, if not already activated\] → Preferences \[under Landmarks, then scroll down\]
--   **Chrome/Opera:** Right-click on, or activate the context menu of, the Landmarks button in the toolbar → Options
+The rest of this file documents information peripheral to the day-to-day use of the extension, that may be of help and interest to web authors/designers/developers, accessibility testers and extension developers.
 
 This Extension's Support for Landmarks
 --------------------------------------

--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ Use the [installation links on the home page](http://matatk.agrip.org.uk/landmar
 * How to navigate using the sidebar (where supported).
 * Border preferences, for landmark highlights and labels whilst navigating.
 
-**If you need support, please [check the known issues for Landmarks](https://github.com/matatk/landmarks/issues) and, if necessary, file a new issue using the "New Issue" button on that page.**
-
 The rest of this file documents information peripheral to the day-to-day use of the extension, that may be of help and interest to web authors/designers/developers, accessibility testers and extension developers.
 
 This Extension's Support for Landmarks

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -154,8 +154,8 @@ async function flattenCode(browser) {
 		input: path.join(srcCodeDir, '_options.js'),
 		output: path.join(pathToBuild(browser), 'options.js')
 	}, {
-		input: path.join(srcCodeDir, '_splash.js'),
-		output: path.join(pathToBuild(browser), 'splash.js')
+		input: path.join(srcCodeDir, '_help.js'),
+		output: path.join(pathToBuild(browser), 'help.js')
 	}, {
 		input: path.join(srcCodeDir, '_gui.js'),
 		output: path.join(pathToBuild(browser), 'popup.js'),

--- a/src/assemble/manifest.common.json
+++ b/src/assemble/manifest.common.json
@@ -23,8 +23,7 @@
     },
     {
       "matches": ["http://matatk.agrip.org.uk/landmarks/"],
-      "js": ["splash.js"],
-      "css": ["splash.css"]
+      "js": ["addHelpLinkToHomePage.js"]
     }
   ],
 

--- a/src/assemble/manifest.opera.json
+++ b/src/assemble/manifest.opera.json
@@ -24,7 +24,7 @@
     "chrome_style": true
   },
 
-  "minimum_opera_version": "44",
+  "minimum_opera_version": "57",
 
   "permissions": ["<all_urls>"],
 

--- a/src/assemble/messages.common.json
+++ b/src/assemble/messages.common.json
@@ -38,7 +38,7 @@
   },
 
   "errorNoConnection": {
-    "message": "Landmarks cannot run on this page."
+    "message": "Landmarks is not allowed to run on this page."
   },
 
   "noLandmarksFound": {

--- a/src/assemble/messages.common.json
+++ b/src/assemble/messages.common.json
@@ -84,11 +84,15 @@
   },
 
   "prefsDeveloper": {
-    "message": "Developer settings"
+    "message": "Debugging"
   },
 
   "prefsDebugInfo": {
     "message": "Show debugging info in the console"
+  },
+
+  "prefsResetAll": {
+    "message": "Reset everything to defaults"
   },
 
 

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -160,6 +160,9 @@ function splashListener(message, sendingPort) {
 				url: browser.runtime.getURL('help.html')
 			})
 			break
+		case 'splash-open-settings':
+			browser.runtime.openOptionsPage()
+			break
 		default:
 			throw Error(`Unknown message from splash: ${JSON.stringify(message)}`)
 	}

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -148,7 +148,7 @@ function splashListener(message, sendingPort) {
 			})
 			break
 		case 'splash-open-configure-shortcuts':
-			browser.tabs.create({
+			browser.tabs.update({
 				// This should only appear on Chrome/Opera
 				url: BROWSER === 'chrome'
 					? 'chrome://extensions/configureCommands'
@@ -156,7 +156,7 @@ function splashListener(message, sendingPort) {
 			})
 			break
 		case 'splash-open-help':
-			browser.tabs.create({
+			browser.tabs.update({
 				url: browser.runtime.getURL('help.html')
 			})
 			break

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -152,7 +152,7 @@ function splashListener(message, sendingPort) {
 				// This should only appear on Chrome/Opera
 				url: BROWSER === 'chrome'
 					? 'chrome://extensions/configureCommands'
-					: 'opera://settings/configureCommands'
+					: 'opera://settings/keyboardShortcuts'
 			})
 			break
 		case 'splash-open-help':

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -389,7 +389,7 @@ browser.tabs.onActivated.addListener(function(activeInfo) {
 
 browser.runtime.onInstalled.addListener(function(details) {
 	if (details.reason === 'install' || details.reason === 'update') {
-		browser.tabs.create({ url: 'help.html' })
+		browser.tabs.create({ url: `help.html#!${details.reason}` })
 	}
 })
 

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -381,11 +381,7 @@ browser.tabs.onActivated.addListener(function(activeInfo) {
 
 browser.runtime.onInstalled.addListener(function(details) {
 	if (details.reason === 'install' || details.reason === 'update') {
-		// Show website and get it to display an appropriate notice
-		const baseUrl = 'http://matatk.agrip.org.uk/landmarks/#!'
-		browser.tabs.create({
-			url: baseUrl + details.reason
-		})
+		browser.tabs.create({ url: 'help.html' })
 	}
 })
 

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -148,11 +148,16 @@ function splashListener(message, sendingPort) {
 			})
 			break
 		case 'splash-open-configure-shortcuts':
-			// This should only appear on Chrome/Opera
 			browser.tabs.create({
+				// This should only appear on Chrome/Opera
 				url: BROWSER === 'chrome'
 					? 'chrome://extensions/configureCommands'
 					: 'opera://settings/configureCommands'
+			})
+			break
+		case 'splash-open-help':
+			browser.tabs.create({
+				url: browser.runtime.getURL('help.html')
 			})
 			break
 		default:

--- a/src/code/_help.js
+++ b/src/code/_help.js
@@ -169,6 +169,10 @@ function main() {
 	port.onDisconnect.addListener(disconnectingPortErrorCheck)
 	port.onMessage.addListener(messageHandler)
 	port.postMessage({ name: 'get-commands' })
+
+	const manifest = browser.runtime.getManifest()
+	const version = manifest.version
+	document.getElementById('version').innerText = version
 }
 
 main()

--- a/src/code/_help.js
+++ b/src/code/_help.js
@@ -4,6 +4,28 @@ import disconnectingPortErrorCheck from './disconnectingPortErrorCheck'
 
 let port
 
+const openingsInstall = {
+	'section-new': false,
+	'section-keyboard-navigation': true,
+	'section-pop-up': true,
+	'section-sidebar': true,
+	'section-border-preferences': true,
+	'section-author-info': true,
+	'section-devtools': true,
+	'section-development': true
+}
+
+const openingsUpdate = {
+	'section-new': true,
+	'section-keyboard-navigation': true,
+	'section-pop-up': false,
+	'section-sidebar': false,
+	'section-border-preferences': false,
+	'section-author-info': false,
+	'section-devtools': false,
+	'section-development': false
+}
+
 const splashPage = {
 	contains: [
 		// more stuff is added later
@@ -177,14 +199,21 @@ function messageHandler(message) {  // also sendingPort
 		contains: shortcutTableRows
 	})
 
-	makePart(splashPage, document.getElementById('keyboard-shortcuts'))
+	makePart(splashPage, document.getElementById('insert-keyboard-shortcuts'))
 }
 
 function makePartInContainers(container, template) {
 	const shortcutLinkContainers = document
-		.querySelectorAll(`[data-container="${container}"`)
+		.querySelectorAll(`[data-link-container="${container}"`)
 	for (const element of shortcutLinkContainers) {
 		makePart(template, element)
+	}
+}
+
+function openings(states) {
+	for (const id in states) {
+		const element = document.getElementById(id)
+		element.open = states[id]
 	}
 }
 
@@ -203,6 +232,18 @@ function main() {
 	const manifest = browser.runtime.getManifest()
 	const version = manifest.version
 	document.getElementById('version').innerText = version
+
+	const fragment = window.location.hash.substr(2)
+	switch(fragment) {
+		case 'install':
+			openings(openingsInstall)
+			break
+		case 'update':
+			openings(openingsUpdate)
+			break
+		default:
+			//
+	}
 }
 
 main()

--- a/src/code/_help.js
+++ b/src/code/_help.js
@@ -20,9 +20,11 @@ const shortcutTableRows = [
 	}
 ]
 
-const chromeKeyboardShortcutsButton = {
+const chromeKeyboardShortcutsLink = {
 	element: 'p', contains: [{
-		element: 'button',
+		element: 'a',
+		class: 'config',
+		href: '#',
 		content: 'Add or change shortcuts',
 		listen: {
 			event: 'click',
@@ -44,6 +46,9 @@ function makePart(structure, root) {
 				break
 			case 'class':
 				newPart.classList.add(structure[key])
+				break
+			case 'href':
+				newPart.href = structure[key]
 				break
 			case 'text':
 				root.appendChild(document.createTextNode(structure[key]))
@@ -157,7 +162,7 @@ function messageHandler(message) {  // also sendingPort
 	})
 
 	if (BROWSER === 'chrome' || BROWSER === 'opera') {
-		splashPage.contains.push(chromeKeyboardShortcutsButton)
+		splashPage.contains.push(chromeKeyboardShortcutsLink)
 	}
 
 	document.getElementById('keyboard-shortcuts').appendChild(

--- a/src/code/_help.js
+++ b/src/code/_help.js
@@ -177,12 +177,15 @@ function messageHandler(message) {  // also sendingPort
 		contains: shortcutTableRows
 	})
 
-	if (BROWSER === 'chrome' || BROWSER === 'opera') {
-		splashPage.contains.push(chromeKeyboardShortcutsLink)
-	}
+	makePart(splashPage, document.getElementById('keyboard-shortcuts'))
+}
 
-	document.getElementById('keyboard-shortcuts').appendChild(
-		makePart(splashPage, document.createElement('div')))
+function makePartInContainers(container, template) {
+	const shortcutLinkContainers = document
+		.querySelectorAll(`[data-container="${container}"`)
+	for (const element of shortcutLinkContainers) {
+		makePart(template, element)
+	}
 }
 
 function main() {
@@ -192,11 +195,10 @@ function main() {
 	port.postMessage({ name: 'get-commands' })
 
 	if (BROWSER === 'chrome' || BROWSER === 'opera') {
-		makePart(chromeKeyboardShortcutsLink,
-			document.getElementById('shortcuts-link-container'))
+		makePartInContainers('shortcuts', chromeKeyboardShortcutsLink)
 	}
 
-	makePart(settingsLink, document.getElementById('settings-link-container'))
+	makePartInContainers('settings', settingsLink)
 
 	const manifest = browser.runtime.getManifest()
 	const version = manifest.version

--- a/src/code/_help.js
+++ b/src/code/_help.js
@@ -35,6 +35,22 @@ const chromeKeyboardShortcutsLink = {
 	}]
 }
 
+const settingsLink = {
+	element: 'a',
+	class: 'config',
+	href: '#',
+	content: 'Change preferences (opens in new tab)',
+	listen: {
+		event: 'click',
+		handler: (event) => {
+			port.postMessage({
+				name: 'splash-open-settings'
+			})
+			event.preventDefault()  // until it opens in the same tab
+		}
+	}
+}
+
 function makePart(structure, root) {
 	let newPart
 
@@ -174,6 +190,13 @@ function main() {
 	port.onDisconnect.addListener(disconnectingPortErrorCheck)
 	port.onMessage.addListener(messageHandler)
 	port.postMessage({ name: 'get-commands' })
+
+	if (BROWSER === 'chrome' || BROWSER === 'opera') {
+		makePart(chromeKeyboardShortcutsLink,
+			document.getElementById('shortcuts-link-container'))
+	}
+
+	makePart(settingsLink, document.getElementById('settings-link-container'))
 
 	const manifest = browser.runtime.getManifest()
 	const version = manifest.version

--- a/src/code/_help.js
+++ b/src/code/_help.js
@@ -4,28 +4,6 @@ import disconnectingPortErrorCheck from './disconnectingPortErrorCheck'
 
 let port
 
-const openingsInstall = {
-	'section-new': false,
-	'section-keyboard-navigation': true,
-	'section-pop-up': true,
-	'section-sidebar': true,
-	'section-border-preferences': true,
-	'section-author-info': true,
-	'section-devtools': true,
-	'section-development': true
-}
-
-const openingsUpdate = {
-	'section-new': true,
-	'section-keyboard-navigation': true,
-	'section-pop-up': false,
-	'section-sidebar': false,
-	'section-border-preferences': false,
-	'section-author-info': false,
-	'section-devtools': false,
-	'section-development': false
-}
-
 const splashPage = {
 	contains: [
 		// more stuff is added later
@@ -210,13 +188,6 @@ function makePartInContainers(container, template) {
 	}
 }
 
-function openings(states) {
-	for (const id in states) {
-		const element = document.getElementById(id)
-		element.open = states[id]
-	}
-}
-
 function main() {
 	port = browser.runtime.connect({ name: 'splash' })
 	port.onDisconnect.addListener(disconnectingPortErrorCheck)
@@ -234,15 +205,12 @@ function main() {
 	document.getElementById('version').innerText = version
 
 	const fragment = window.location.hash.substr(2)
-	switch(fragment) {
-		case 'install':
-			openings(openingsInstall)
-			break
-		case 'update':
-			openings(openingsUpdate)
-			break
-		default:
-			//
+	if (fragment === 'update') {
+		document.getElementById('section-new').open = true
+	}
+
+	if (BROWSER === 'firefox' || BROWSER === 'opera') {
+		document.getElementById('section-sidebar').open = true
 	}
 }
 

--- a/src/code/_help.js
+++ b/src/code/_help.js
@@ -33,7 +33,6 @@ const chromeKeyboardShortcutsButton = {
 	}]
 }
 
-
 function makePart(structure, root) {
 	let newPart
 
@@ -68,7 +67,6 @@ function makePart(structure, root) {
 
 	return root
 }
-
 
 function addCommandRowAndReportIfMissing(command) {
 	// Work out the command's friendly name
@@ -114,7 +112,6 @@ function addCommandRowAndReportIfMissing(command) {
 	})
 }
 
-
 function firefoxShortcutElements(shortcut) {
 	const shortcutElements = []
 	const shortcutParts = shortcut.split(/(\+)/)
@@ -129,7 +126,6 @@ function firefoxShortcutElements(shortcut) {
 
 	return shortcutElements
 }
-
 
 function messageHandler(message) {  // also sendingPort
 	if (message.name !== 'splash-populate-commands') return
@@ -164,47 +160,11 @@ function messageHandler(message) {  // also sendingPort
 		splashPage.contains.push(chromeKeyboardShortcutsButton)
 	}
 
-	// Create new bits
-
-	const heading = document.getElementById('via-shortcut-key')
-	const parent = heading.parentNode
-	const splashContainer = document.createElement('div')
-
-	parent.insertBefore(
-		makePart(splashPage, splashContainer), heading.nextSibling)
+	document.getElementById('keyboard-shortcuts').appendChild(
+		makePart(splashPage, document.createElement('div')))
 }
 
-
 function main() {
-	// Check for various README elements and escape if things aren't as expected
-
-	const installationTocEntry = document.getElementsByTagName('li')[0]
-	if (!installationTocEntry
-		|| installationTocEntry.textContent !== 'Installation') return
-
-	const installationHeading = document.getElementById('installation')
-	if (!installationHeading) return
-
-	const shortcutKeysHeading = document.getElementById('via-shortcut-key')
-	if (!shortcutKeysHeading) return
-
-	// Remove installation section
-
-	installationTocEntry.remove()
-
-	while (installationHeading.nextSibling.tagName !== 'H2') {  // FIXME H
-		installationHeading.nextSibling.remove()
-	}
-
-	installationHeading.remove()
-
-	// Remove static keyboard shortcuts section content
-
-	while (shortcutKeysHeading.nextSibling.tagName !== 'H3') {  // FIXME H
-		shortcutKeysHeading.nextSibling.remove()
-	}
-
-	// Kickstart process to get commands and create new HTML
 	port = browser.runtime.connect({ name: 'splash' })
 	port.onDisconnect.addListener(disconnectingPortErrorCheck)
 	port.onMessage.addListener(messageHandler)

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -65,6 +65,8 @@ function setUpOptionHandlers() {
 	if (BROWSER === 'firefox' || BROWSER === 'opera') {
 		document.getElementById('reset-messages').onclick = resetMessages
 	}
+
+	document.getElementById('reset-all').onclick = resetAll
 }
 
 function interfaceExplainer() {
@@ -109,6 +111,11 @@ function resetMessages() {
 
 function dismissalStateChanged(thingChanged) {
 	return dismissalStates.hasOwnProperty(thingChanged)
+}
+
+function resetAll() {
+	browser.storage.sync.clear()
+	window.location.reload()
 }
 
 function main() {

--- a/src/code/isContentScriptablePage.js
+++ b/src/code/isContentScriptablePage.js
@@ -8,14 +8,10 @@ const specialPages
 /* eslint-enable indent */
 
 export default function isContentScriptablePage(url) {
-	if (/^(https?|file):\/\//.test(url) && !specialPages.test(url)) {
-		return true
-	}
+	if (/^(https?|file):\/\//.test(url) && !specialPages.test(url)) return true
 	if (BROWSER === 'firefox') {
 		const helpPageUrl = browser.runtime.getURL('help.html')
-		if (url === helpPageUrl) {
-			return true
-		}
+		if (url.startsWith(helpPageUrl)) return true
 	}
 	return false
 }

--- a/src/code/isContentScriptablePage.js
+++ b/src/code/isContentScriptablePage.js
@@ -11,5 +11,11 @@ export default function isContentScriptablePage(url) {
 	if (/^(https?|file):\/\//.test(url) && !specialPages.test(url)) {
 		return true
 	}
+	if (BROWSER === 'firefox') {
+		const helpPageUrl = browser.runtime.getURL('help.html')
+		if (url === helpPageUrl) {
+			return true
+		}
+	}
 	return false
 }

--- a/src/static/addHelpLinkToHomePage.js
+++ b/src/static/addHelpLinkToHomePage.js
@@ -1,0 +1,28 @@
+'use strict'
+const para = document.createElement('p')
+para.style.margin = 0
+para.style.padding = '1em'
+para.style.fontSize = '1.5em'
+para.style.backgroundColor = 'black'
+para.style.textAlign = 'center'
+para.style.lineHeight = '1.5em'
+para.style.fontWeight = 'bold'
+
+const link = document.createElement('a')
+link.href = '#'
+link.onclick = function() {
+	const port = browser.runtime.connect({ name: 'splash' })
+	port.postMessage({
+		name: 'splash-open-help'
+	})
+	port.disconnect()
+}
+link.appendChild(document.createTextNode(
+	"You've already got the Landmarks extension; visit the help page..."))
+link.style.color = 'white'
+
+para.appendChild(link)
+if (document.body.firstChild.tagName === 'P') {
+	document.body.firstChild.remove()
+}
+document.body.insertBefore(para, document.body.firstChild)

--- a/src/static/gui.css
+++ b/src/static/gui.css
@@ -33,9 +33,15 @@ h1 {
 }
 
 /* ui */
+:root {
+	--light: #e4fbf0;
+	--vivid: #159957;
+}
+
 #note {
-	background-color: #fee;
-	border: 1px solid red;
+	background-color: var(--light);
+	border: 1px solid var(--vivid);
+	border-radius: 1em;
 }
 
 #note p {
@@ -50,8 +56,9 @@ h1 {
 
 #note button {
 	flex-grow: 1;
-	border-color: red;
-	background-color: #fee;
+	border-color: var(--vivid);
+	background-color: var(--light);
+	border-radius: 1em;
 	text-align: center;
 }
 /* /ui */

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -33,6 +33,11 @@ details {
 	border-bottom: 1px solid var(--words);
 }
 
+details.call-to-action {
+	border: none;
+	background-color: #eee;
+}
+
 details:not(:first-child) {
 	margin-top: 2em;
 }

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -58,7 +58,7 @@ td.error {
 a.config {
 	display: inline-block;
 	border-radius: 1em;
-	border: 2px solid var(--words);
+	border: 1px solid var(--words);
 	padding: 1em;
 	color: var(--words);
 }

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -60,6 +60,7 @@ a.config {
 	border-radius: 1em;
 	border: 2px solid var(--words);
 	padding: 1em;
+	color: var(--words);
 }
 
 footer { padding: 1em; }

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -24,11 +24,17 @@ header a {
 	font-weight: bold;
 }
 
-main { padding-top: 1em; }
+main { padding-top: 2em; }
 
 details {
 	padding: 1em;
-	margin: 0;
+	margin: 2em;
+	margin-top: 0;
+	border-bottom: 1px solid var(--words);
+}
+
+details:not(:first-child) {
+	margin-top: 2em;
 }
 
 summary > :first-child { display: inline; }
@@ -68,14 +74,15 @@ a.config {
 	color: var(--words);
 }
 
-footer { padding: 1em; }
+footer { padding: 2em; }
 
 footer a { color: var(--words); }
 
-@media screen and (min-width: 60em) {
+@media screen and (min-width: 80em) {
 	main {
 		column-count: 2;
 		column-fill: balance;
+		column-gap: 0;
 	}
 
 	details {

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -27,9 +27,26 @@ details {
 
 summary > :first-child { display: inline; }
 
-footer { padding: 1em; }
+table {
+	margin-top: 0.5em;
+	border-collapse: collapse;
+}
 
-footer a { color: var(--words); }
+tr:nth-child(odd) { background-color: #efefef; }
+
+tr:first-child {
+	background-color: var(--hla);
+	color: white;
+}
+
+th, td { padding: 0.5em; }
+
+th {
+	padding-left: 2em;
+	padding-right: 2em;
+}
+
+td:last-child { text-align: center; }
 
 td.error {
 	background-color: #d00;
@@ -37,15 +54,20 @@ td.error {
 	font-weight: bold;
 }
 
+button { font-size: inherit; }
+
+footer { padding: 1em; }
+
+footer a { color: var(--words); }
+
 @media screen and (min-width: 60em) {
 	main {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: space-between;
+		column-count: 2;
+		column-fill: balance;
 	}
 
 	details {
-		margin: 0;
-		width: 47%;
+		break-inside: avoid;
+		page-break-inside: avoid;  /* for Firefox */
 	}
 }

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -8,6 +8,7 @@ body {
 	margin: 0;
 	font-family: Verdana, sans-serif;
 	color: var(--words);
+	font-size: 1em;  /* if not given, text is small in Chrome-like browsers */
 	line-height: 1.5em;
 }
 

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -31,6 +31,12 @@ footer { padding: 1em; }
 
 footer a { color: var(--words); }
 
+td.error {
+	background-color: #d00;
+	color: white;
+	font-weight: bold;
+}
+
 @media screen and (min-width: 60em) {
 	main {
 		display: flex;

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -19,6 +19,11 @@ header {
 	color: white;
 }
 
+header a {
+	color: white;
+	font-weight: bold;
+}
+
 main { padding-top: 1em; }
 
 details {

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -1,0 +1,45 @@
+:root {
+	--hla: #155799;
+	--hlb: #159957;
+	--words: #606c71;
+}
+
+body {
+	margin: 0;
+	font-family: Verdana, sans-serif;
+	color: var(--words);
+	line-height: 1.5em;
+}
+
+header {
+	background-image: linear-gradient(120deg, var(--hla), var(--hlb));
+	padding: 2em;
+	margin: 0;
+	color: white;
+}
+
+main { padding-top: 1em; }
+
+details {
+	padding: 1em;
+	margin: 0;
+}
+
+summary > :first-child { display: inline; }
+
+footer { padding: 1em; }
+
+footer a { color: var(--words); }
+
+@media screen and (min-width: 60em) {
+	main {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+	}
+
+	details {
+		margin: 0;
+		width: 47%;
+	}
+}

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -55,7 +55,12 @@ td.error {
 	font-weight: bold;
 }
 
-button { font-size: inherit; }
+a.config {
+	display: inline-block;
+	border-radius: 1em;
+	border: 2px solid var(--words);
+	padding: 1em;
+}
 
 footer { padding: 1em; }
 

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -10,29 +10,75 @@
 			<h1>Landmarks Help</h1>
 		</header>
 		<main>
-		<details>
+		<details open>
 			<summary><h2>What's New?</h2></summary>
-			<p>Hello.</p>
+			<p>FIXME TODO</p>
 		</details>
-		<details>
+		<details open>
 			<summary><h2>Keyboard shortcuts</h2></summary>
 			<p>Hello.</p>
 		</details>
-		<details>
+		<details open>
 			<summary><h2>Navigation</h2></summary>
-			<p>Hello.</p>
+			<h3 id="via-shortcut-key">Via Shortcut Key</h3>
+			<p>You can use shortcut keys to navigate between landmarks. By default, the keys are:</p>
+			<ul>
+				<li><strong>Next landmark:</strong> <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></li>
+				<li><strong>Previous landmark:</strong> <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd></li>
+				<li><strong>Main landmark:</strong> <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd></li>
+				<li><strong>Open the landmarks pop-up:</strong> <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd>, then use <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> to move between buttons, <kbd>Space</kbd> or <kbd>Enter</kbd> to move focus to a landmark and <kbd>Escape</kbd> to close the pop-up.</li>
+			</ul>
+			<p>(On a Mac, use the <kbd>Option</kbd> key, which is equivalent to <kbd>Alt</kbd>.)</p>
+			<p>Landmarks will be focused, and a border shown according to your <a href="#border-preferences">border preferences</a>.</p>
+			<p>You can change the keyboard shortcuts in the following browsers.</p>
+			<ul>
+				<li><strong>Chrome:</strong> More ⋮ → Settings → Extensions [on the left-hand side] → Keyboard shortcuts [at the bottom of the page]</li>
+				<li><strong>Opera:</strong> Opera Menu / Speed Dial → Extensions → Extension Keyboard Shortcuts</li>
+			</ul>
+			<h3 id="via-toolbar-pop-up">Via Toolbar Pop-up</h3>
+			<p>If landmarks are found on the page, the Landmarks button in the toolbar (which looks like an “L”) will be badged with the number of landmarks found.</p>
+			<ol>
+				<li>
+					<p>Activate the Landmarks toolbar button. A pop-up will appear. If landmarks are present on the page, they will be shown in a nested list, reflecting the structure of the landmarks on the page.</p>
+				</li>
+				<li>
+					<p>Activate a button in the list to move to that landmark. The landmark will be focused, and a border shown according to your <a href="#border-preferences">border preferences</a>.</p>
+				</li>
+				<li>
+					<p>To close the pop-up, press <kbd>Escape</kbd>, or click outside of the pop-up.</p>
+				</li>
+			</ol>
+			<h3 id="inspecting-landmarks-in-the-dom">Inspecting landmarks in the DOM</h3>
+			<p>A Developer Tools panel called “Landmarks” is also provided. This can be used in the same way as the pop-up above, but also allows you to visit each landmark element in the DOM inspector, using inspection buttons that are placed immediately after the button for each landmark.</p> <p>This feature is primarily intended for web authors/developers and accessibility testers.</p>
 		</details>
-		<details>
-			<summary><h2>Preferences</h2></summary>
-			<p>Hello.</p>
+		<details open>
+			<summary><h2 id="border-preferences">Preferences</h2></summary>
+			<p>A border will be drawn around the landmarks as you navigate them. The border contains a label that displays the landmark’s type and name (if one was provided by the author of the page). You can customise various aspects of this in the extension’s preferences/options page. The available settings are:</p>
+			<ul>
+				<li><strong>If the border should be displayed, and for how long.</strong>
+					<ul>
+						<li><strong>Momentary (default):</strong> the border remains visible for a short time, then disappears.</li>
+						<li><strong>Persistent:</strong> the border remains visible at all times.</li>
+						<li><strong>None:</strong> no border is drawn.</li>
+					</ul>
+				</li>
+				<li><strong>The border’s colour.</strong></li>
+				<li><strong>The font size used in the landmark label.</strong></li>
+			</ul>
+			<p>You can get to the extension’s settings as follows.</p>
+			<ul>
+				<li><strong>Firefox:</strong> Menu ☰ → Add-ons → Extensions [on left-hand side, if not already activated] → Preferences [under Landmarks, then scroll down]</li>
+				<li><strong>Chrome/Opera:</strong> Right-click on, or activate the context menu of, the Landmarks button in the toolbar → Options</li>
+			</ul>
 		</details>
-		<details>
+		<details open>
 			<summary><h2>Info for web authors and developers</h2></summary>
-			<p>Hello.</p>
+			<p>You can learn about <a href="https://github.com/matatk/landmarks#information-for-web-authors-designers-and-developers">why landmarks rock, and how easy they are to use on your site</a> in the README on GitHub.</p>
+			<p>You can learn about <a href="https://github.com/matatk/landmarks#this-extensions-support-for-landmarks">this extension's support for the landmarks standards</a> in the README on GitHub.</p>
 		</details>
-		<details>
+		<details open>
 			<summary><h2>Landmarks extension development info</h2></summary>
-			<p>Hello.</p>
+			<p>Check out the <a href="https://github.com/matatk/landmarks#development">Development</a> section of the README on GitHub.</p>
 		</details>
 		</main>
 		<footer>

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -10,15 +10,15 @@
 			<h1>Landmarks Help</h1>
 		</header>
 		<main>
-		<details open>
+		<details id="section-new" open>
 			<summary><h2>What's New?</h2></summary>
 			<p>New in version <span id="version"></span>&hellip;</p>
 			<p><mark>FIXME TODO</mark></p>
 		</details>
-		<details open>
+		<details id="section-keyboard-navigation" open>
 			<summary><h2>Keyboard Navigation</h2></summary>
-			<p>You can use shortcut keys to navigate between landmarks, as detailed below. When you do, landmarks will be focused, and a border shown according to your <a href="#border-preferences">border preferences</a>.</p>
-			<div id="keyboard-shortcuts"></div>
+			<p>You can use shortcut keys to navigate between landmarks, as detailed below. When you do, landmarks will be focused, and a border shown according to your <a href="#section-border-preferences">border preferences</a>.</p>
+			<div id="insert-keyboard-shortcuts"></div>
 			<p data-container="shortcuts"></p>
 			<p>You can also change the keyboard shortcuts in the following browsers.</p>
 			<ul>
@@ -26,7 +26,7 @@
 				<li><strong>Opera:</strong> Opera Menu / Speed Dial → Extensions → Extension Keyboard Shortcuts</li>
 			</ul>
 		</details>
-		<details open>
+		<details id="section-pop-up" open>
 			<summary><h2>Toolbar Pop-up</h2></summary>
 			<p>If landmarks are found on the page, the Landmarks button in the toolbar (which looks like an "L") will be badged with the number of landmarks found. You can use the pop-up as follows.</p>
 			<ol>
@@ -34,25 +34,25 @@
 					<p>Activate the Landmarks toolbar button. A pop-up will appear. If landmarks are present on the page, they will be shown in a nested list, reflecting the structure of the landmarks on the page.</p>
 				</li>
 				<li>
-					<p>Activate a button in the list to move to that landmark. The landmark will be focused, and a border shown according to your <a href="#border-preferences">border preferences</a>.</p>
+					<p>Activate a button in the list to move to that landmark. The landmark will be focused, and a border shown according to your <a href="#section-border-preferences">border preferences</a>.</p>
 				</li>
 				<li>
 					<p>To close the pop-up, press <kbd>Escape</kbd>, or click outside of the pop-up.</p>
 				</li>
 			</ol>
 		</details>
-		<details open>
+		<details id="section-sidebar" open>
 			<summary><h2>Sidebar</h2></summary>
 			<p>On Firefox and Opera, you can also explore landmarks on the page by way of a sidebar. You can choose in the preferences whether you'd like to use both the toolbar pop-up and sidebar, or just the sidebar.</p>
-			<p data-container="settings"></p>
+			<p data-link-container="settings"></p>
 			<p>You can also get to the extension’s settings as follows.</p>
 			<ul>
 				<li><strong>Firefox:</strong> Menu ☰ → Add-ons → Extensions [on left-hand side, if not already activated] → Preferences [under Landmarks, then scroll down]</li>
-				<li><strong>Chrome/Opera:</strong> Right-click on, or activate the context menu of, the Landmarks button in the toolbar → Options</li>
+				<li><strong>Opera:</strong> Right-click on, or activate the context menu of, the Landmarks button in the toolbar → Options</li>
 			</ul>
 		</details>
-		<details open>
-			<summary><h2 id="border-preferences">Preferences</h2></summary>
+		<details id="section-border-preferences" open>
+			<summary><h2>Border preferences</h2></summary>
 			<p>A border will be drawn around the landmarks as you navigate them. The border contains a label that displays the landmark’s type and name (if one was provided by the author of the page). You can customise various aspects of this in the extension’s preferences/options page. The available settings are:</p>
 			<ul>
 				<li><strong>If the border should be displayed, and for how long.</strong>
@@ -65,23 +65,23 @@
 				<li><strong>The border’s colour.</strong></li>
 				<li><strong>The font size used in the landmark label.</strong></li>
 			</ul>
-			<p data-container="settings"></p>
+			<p data-link-container="settings"></p>
 			<p>You can also get to the extension’s settings as follows.</p>
 			<ul>
 				<li><strong>Firefox:</strong> Menu ☰ → Add-ons → Extensions [on left-hand side, if not already activated] → Preferences [under Landmarks, then scroll down]</li>
 				<li><strong>Chrome/Opera:</strong> Right-click on, or activate the context menu of, the Landmarks button in the toolbar → Options</li>
 			</ul>
 		</details>
-		<details open>
+		<details id="section-author-info" open>
 			<summary><h2>Info for web authors and developers</h2></summary>
 			<p>You can learn about <a href="https://github.com/matatk/landmarks#information-for-web-authors-designers-and-developers">why landmarks rock, and how easy they are to use on your site</a> in the README on GitHub.</p>
 			<p>You can learn about <a href="https://github.com/matatk/landmarks#this-extensions-support-for-landmarks">this extension's support for the landmarks standards</a> in the README on GitHub.</p>
 		</details>
-		<details open>
+		<details id="section-devtools" open>
 			<summary><h2>Inspecting landmarks in the DOM</h2></summary>
 			<p>A Developer Tools panel called “Landmarks” is also provided. This can be used in the same way as the pop-up above, but also allows you to visit each landmark element in the DOM inspector, using inspection buttons that are placed immediately after the button for each landmark.</p> <p>This feature is primarily intended for web authors/developers and accessibility testers.</p>
 		</details>
-		<details open>
+		<details id="section-development" open>
 			<summary><h2>Landmarks extension development info</h2></summary>
 			<p>Check out the <a href="https://github.com/matatk/landmarks#development">Development</a> section of the README on GitHub.</p>
 		</details>

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -12,6 +12,21 @@
 			<p>If you need support, please <a href="https://github.com/matatk/landmarks/issues">check the known issues for Landmarks</a> and, if necessary, file a new issue using the "New Issue" button on that page.</p>
 		</header>
 		<main>
+		<details class="call-to-action" id="actions-install" open>
+			<summary><h2>Thanks for installing Landmarks</h2></summary>
+			<p>You may want to learn how to <a href="#section-keyboard-navigation">navigate via keyboard</a> and set up keyboard shortcuts.</p>
+		</details>
+		<details class="call-to-action" id="actions-update" open>
+			<summary><h2>Landmarks was updated</h2></summary>
+			<ul>
+				<li>
+					<p>Check out <a href="#section-new">what's new</a>.</p>
+				</li>
+				<li>
+					<p>Learn how to <a href="#section-keyboard-navigation">navigate via keyboard</a> and set up keyboard shortcuts.</p>
+				</li>
+			</ul>
+		</details>
 		<details id="section-new">
 			<summary><h2>What's new?</h2></summary>
 			<p>New in version <span id="version"></span>&hellip;</p>
@@ -25,11 +40,11 @@
 			</ul>
 			<p>For more details, consult the <a href="https://github.com/matatk/landmarks/blob/master/CHANGELOG.md#landmarks-changelog">change log</a>.</p>
 		</details>
-		<details open>
+		<details id="section-keyboard-navigation" open>
 			<summary><h2>Keyboard navigation</h2></summary>
 			<p>You can use shortcut keys to navigate between landmarks, as detailed below. When you do, landmarks will be focused, and a border shown according to your <a href="#section-border-preferences">border preferences</a>.</p>
-			<div id="insert-keyboard-shortcuts"></div>
-			<p data-container="shortcuts"></p>
+			<div id="keyboard-shortcuts-table"></div>
+			<p data-link="shortcuts"></p>
 			<p>You can also change the keyboard shortcuts in the following browsers.</p>
 			<ul>
 				<li>
@@ -58,7 +73,7 @@
 		<details id="section-sidebar">
 			<summary><h2>Sidebar</h2></summary>
 			<p>On Firefox and Opera, you can also explore landmarks on the page by way of a sidebar. You can choose in the preferences whether you'd like to use both the toolbar pop-up and sidebar, or just the sidebar.</p>
-			<p data-link-container="settings"></p>
+			<p data-link="settings"></p>
 			<!-- Note: the following is almost identical in the Border Preferences section below. -->
 			<p>You can also get to the extension’s settings as follows.</p>
 			<ul>
@@ -70,7 +85,7 @@
 				</li>
 			</ul>
 		</details>
-		<details open>
+		<details id="section-border-preferences" open>
 			<summary><h2>Border preferences</h2></summary>
 			<p>A border will be drawn around the landmarks as you navigate them. The border contains a label that displays the landmark’s type and name (if one was provided by the author of the page). You can customise various aspects of this in the extension’s preferences/options page. The available settings are:</p>
 			<ul>
@@ -95,7 +110,7 @@
 					<p><strong>The font size used in the landmark label.</strong></p>
 				</li>
 			</ul>
-			<p data-link-container="settings"></p>
+			<p data-link="settings"></p>
 			<!-- Note: the following is almost identical in the Sidebar section above. -->
 			<p>You can also get to the extension’s settings as follows.</p>
 			<ul>

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -21,7 +21,9 @@
 		<details open>
 			<summary><h2>Navigation</h2></summary>
 			<h3>Shortcut Keys</h3>
-			<p>You can use shortcut keys to navigate between landmarks, as detailed above. When you do, landmarks will be focused, and a border shown according to your <a href="#border-preferences">border preferences</a>. You can change the keyboard shortcuts in the following browsers.</p>
+			<p>You can use shortcut keys to navigate between landmarks, as detailed above. When you do, landmarks will be focused, and a border shown according to your <a href="#border-preferences">border preferences</a>.</p>
+			<p id="shortcuts-link-container"></p>
+			<p>You can also change the keyboard shortcuts in the following browsers.</p>
 			<ul>
 				<li><strong>Chrome:</strong> More ⋮ → Settings → Extensions [on the left-hand side] → Keyboard shortcuts [at the bottom of the page]</li>
 				<li><strong>Opera:</strong> Opera Menu / Speed Dial → Extensions → Extension Keyboard Shortcuts</li>
@@ -56,7 +58,8 @@
 				<li><strong>The border’s colour.</strong></li>
 				<li><strong>The font size used in the landmark label.</strong></li>
 			</ul>
-			<p>You can get to the extension’s settings as follows.</p>
+			<p id="settings-link-container"></p>
+			<p>You can also get to the extension’s settings as follows.</p>
 			<ul>
 				<li><strong>Firefox:</strong> Menu ☰ → Add-ons → Extensions [on left-hand side, if not already activated] → Preferences [under Landmarks, then scroll down]</li>
 				<li><strong>Chrome/Opera:</strong> Right-click on, or activate the context menu of, the Landmarks button in the toolbar → Options</li>

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -14,28 +14,20 @@
 			<summary><h2>What's New?</h2></summary>
 			<p>FIXME TODO</p>
 		</details>
-		<details open>
+		<details id="keyboard-shortcuts" open>
 			<summary><h2>Keyboard shortcuts</h2></summary>
-			<p>Hello.</p>
 		</details>
 		<details open>
 			<summary><h2>Navigation</h2></summary>
-			<h3 id="via-shortcut-key">Via Shortcut Key</h3>
-			<p>You can use shortcut keys to navigate between landmarks. By default, the keys are:</p>
-			<ul>
-				<li><strong>Next landmark:</strong> <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></li>
-				<li><strong>Previous landmark:</strong> <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd></li>
-				<li><strong>Main landmark:</strong> <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd></li>
-				<li><strong>Open the landmarks pop-up:</strong> <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd>, then use <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> to move between buttons, <kbd>Space</kbd> or <kbd>Enter</kbd> to move focus to a landmark and <kbd>Escape</kbd> to close the pop-up.</li>
-			</ul>
-			<p>(On a Mac, use the <kbd>Option</kbd> key, which is equivalent to <kbd>Alt</kbd>.)</p>
-			<p>Landmarks will be focused, and a border shown according to your <a href="#border-preferences">border preferences</a>.</p>
+			<h3>Shortcut Keys</h3>
+			<p>You can use shortcut keys to navigate between landmarks, as detailed above.</p>
+			<p>When you do, landmarks will be focused, and a border shown according to your <a href="#border-preferences">border preferences</a>.</p>
 			<p>You can change the keyboard shortcuts in the following browsers.</p>
 			<ul>
 				<li><strong>Chrome:</strong> More ⋮ → Settings → Extensions [on the left-hand side] → Keyboard shortcuts [at the bottom of the page]</li>
 				<li><strong>Opera:</strong> Opera Menu / Speed Dial → Extensions → Extension Keyboard Shortcuts</li>
 			</ul>
-			<h3 id="via-toolbar-pop-up">Via Toolbar Pop-up</h3>
+			<h3>Toolbar Pop-up</h3>
 			<p>If landmarks are found on the page, the Landmarks button in the toolbar (which looks like an “L”) will be badged with the number of landmarks found.</p>
 			<ol>
 				<li>
@@ -48,7 +40,7 @@
 					<p>To close the pop-up, press <kbd>Escape</kbd>, or click outside of the pop-up.</p>
 				</li>
 			</ol>
-			<h3 id="inspecting-landmarks-in-the-dom">Inspecting landmarks in the DOM</h3>
+			<h3>Inspecting landmarks in the DOM</h3>
 			<p>A Developer Tools panel called “Landmarks” is also provided. This can be used in the same way as the pop-up above, but also allows you to visit each landmark element in the DOM inspector, using inspection buttons that are placed immediately after the button for each landmark.</p> <p>This feature is primarily intended for web authors/developers and accessibility testers.</p>
 		</details>
 		<details open>
@@ -85,5 +77,6 @@
 			<p><a href="https://github.com/matatk/landmarks">Landmarks</a> is maintained by <a href="https://github.com/matatk">matatk</a>. <p>Gradient design is from the <a href="https://github.com/jasonlong/cayman-theme">Cayman theme</a>.</p>
 		</footer>
 		<script src="content.js"></script>
+		<script src="help.js"></script>
 	</body>
 </html>

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title>Landmarks Help</title>
+		<link rel="stylesheet" href="help.css">
+	</head>
+	<body>
+		<header>
+			<h1>Landmarks Help</h1>
+		</header>
+		<main>
+		<details>
+			<summary><h2>What's New?</h2></summary>
+			<p>Hello.</p>
+		</details>
+		<details>
+			<summary><h2>Keyboard shortcuts</h2></summary>
+			<p>Hello.</p>
+		</details>
+		<details>
+			<summary><h2>Navigation</h2></summary>
+			<p>Hello.</p>
+		</details>
+		<details>
+			<summary><h2>Preferences</h2></summary>
+			<p>Hello.</p>
+		</details>
+		<details>
+			<summary><h2>Info for web authors and developers</h2></summary>
+			<p>Hello.</p>
+		</details>
+		<details>
+			<summary><h2>Landmarks extension development info</h2></summary>
+			<p>Hello.</p>
+		</details>
+		</main>
+		<footer>
+			<p><a href="https://github.com/matatk/landmarks">Landmarks</a> is maintained by <a href="https://github.com/matatk">matatk</a>. <p>Gradient design is from the <a href="https://github.com/jasonlong/cayman-theme">Cayman theme</a>.</p>
+		</footer>
+		<script src="content.js"></script>
+	</body>
+</html>

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>Landmarks Help</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="stylesheet" href="help.css">
 	</head>
 	<body>
@@ -11,24 +12,36 @@
 			<p>If you need support, please <a href="https://github.com/matatk/landmarks/issues">check the known issues for Landmarks</a> and, if necessary, file a new issue using the "New Issue" button on that page.</p>
 		</header>
 		<main>
-		<details id="section-new" open>
-			<summary><h2>What's New?</h2></summary>
+		<details id="section-new">
+			<summary><h2>What's new?</h2></summary>
 			<p>New in version <span id="version"></span>&hellip;</p>
-			<p><mark>FIXME TODO</mark></p>
+			<ul>
+				<li>
+					<p><mark>FIXME</mark></p>
+				</li>
+				<li>
+					<p><mark>TODO</mark></p>
+				</li>
+			</ul>
+			<p>For more details, consult the <a href="https://github.com/matatk/landmarks/blob/master/CHANGELOG.md#landmarks-changelog">change log</a>.</p>
 		</details>
-		<details id="section-keyboard-navigation" open>
-			<summary><h2>Keyboard Navigation</h2></summary>
+		<details open>
+			<summary><h2>Keyboard navigation</h2></summary>
 			<p>You can use shortcut keys to navigate between landmarks, as detailed below. When you do, landmarks will be focused, and a border shown according to your <a href="#section-border-preferences">border preferences</a>.</p>
 			<div id="insert-keyboard-shortcuts"></div>
 			<p data-container="shortcuts"></p>
 			<p>You can also change the keyboard shortcuts in the following browsers.</p>
 			<ul>
-				<li><strong>Chrome:</strong> More ⋮ → Settings → Extensions [on the left-hand side] → Keyboard shortcuts [at the bottom of the page]</li>
-				<li><strong>Opera:</strong> Opera Menu / Speed Dial → Extensions → Extension Keyboard Shortcuts</li>
+				<li>
+					<p><strong>Chrome:</strong> More ⋮ → Settings → Extensions [on the left-hand side] → Keyboard shortcuts [at the bottom of the page]</p>
+				</li>
+				<li>
+					<p><strong>Opera:</strong> Opera Menu / Speed Dial → Extensions → Extension Keyboard Shortcuts</p>
+				</li>
 			</ul>
 		</details>
-		<details id="section-pop-up" open>
-			<summary><h2>Toolbar Pop-up</h2></summary>
+		<details open>
+			<summary><h2>Toolbar pop-up</h2></summary>
 			<p>If landmarks are found on the page, the Landmarks button in the toolbar (which looks like an "L") will be badged with the number of landmarks found. You can use the pop-up as follows.</p>
 			<ol>
 				<li>
@@ -42,48 +55,69 @@
 				</li>
 			</ol>
 		</details>
-		<details id="section-sidebar" open>
+		<details id="section-sidebar">
 			<summary><h2>Sidebar</h2></summary>
 			<p>On Firefox and Opera, you can also explore landmarks on the page by way of a sidebar. You can choose in the preferences whether you'd like to use both the toolbar pop-up and sidebar, or just the sidebar.</p>
 			<p data-link-container="settings"></p>
+			<!-- Note: the following is almost identical in the Border Preferences section below. -->
 			<p>You can also get to the extension’s settings as follows.</p>
 			<ul>
-				<li><strong>Firefox:</strong> Menu ☰ → Add-ons → Extensions [on left-hand side, if not already activated] → Preferences [under Landmarks, then scroll down]</li>
-				<li><strong>Opera:</strong> Right-click on, or activate the context menu of, the Landmarks button in the toolbar → Options</li>
+				<li>
+					<p><strong>Firefox:</strong> Menu ☰ → Add-ons → Extensions [on left-hand side, if not already activated] → Preferences [under Landmarks, then scroll down]</p>
+				</li>
+				<li>
+					<p><strong>Opera:</strong> Right-click on, or activate the context menu of, the Landmarks button in the toolbar → Options</p>
+				</li>
 			</ul>
 		</details>
-		<details id="section-border-preferences" open>
+		<details open>
 			<summary><h2>Border preferences</h2></summary>
 			<p>A border will be drawn around the landmarks as you navigate them. The border contains a label that displays the landmark’s type and name (if one was provided by the author of the page). You can customise various aspects of this in the extension’s preferences/options page. The available settings are:</p>
 			<ul>
-				<li><strong>If the border should be displayed, and for how long.</strong>
+				<li>
+					<p><strong>If the border should be displayed, and for how long.</strong></p>
 					<ul>
-						<li><strong>Momentary (default):</strong> the border remains visible for a short time, then disappears.</li>
-						<li><strong>Persistent:</strong> the border remains visible at all times.</li>
-						<li><strong>None:</strong> no border is drawn.</li>
+						<li>
+							<p><strong>Momentary (default):</strong> the border remains visible for a short time, then disappears.</p>
+						</li>
+						<li>
+							<p><strong>Persistent:</strong> the border remains visible at all times.</p>
+						</li>
+						<li>
+							<p><strong>None:</strong> no border is drawn.</p>
+						</li>
 					</ul>
 				</li>
-				<li><strong>The border’s colour.</strong></li>
-				<li><strong>The font size used in the landmark label.</strong></li>
+				<li>
+					<p><strong>The border’s colour.</strong></p>
+				</li>
+				<li>
+					<p><strong>The font size used in the landmark label.</strong></p>
+				</li>
 			</ul>
 			<p data-link-container="settings"></p>
+			<!-- Note: the following is almost identical in the Sidebar section above. -->
 			<p>You can also get to the extension’s settings as follows.</p>
 			<ul>
-				<li><strong>Firefox:</strong> Menu ☰ → Add-ons → Extensions [on left-hand side, if not already activated] → Preferences [under Landmarks, then scroll down]</li>
-				<li><strong>Chrome/Opera:</strong> Right-click on, or activate the context menu of, the Landmarks button in the toolbar → Options</li>
+				<li>
+					<p><strong>Firefox:</strong> Menu ☰ → Add-ons → Extensions [on left-hand side, if not already activated] → Preferences [under Landmarks, then scroll down]</p>
+				</li>
+				<li>
+					<p><strong>Chrome/Opera:</strong> Right-click on, or activate the context menu of, the Landmarks button in the toolbar → Options</p>
+				</li>
 			</ul>
 		</details>
-		<details id="section-author-info" open>
-			<summary><h2>Info for web authors and developers</h2></summary>
+		<details open>
+			<summary><h2>Information for web authors, designers and developers</h2></summary>
 			<p>You can learn about <a href="https://github.com/matatk/landmarks#information-for-web-authors-designers-and-developers">why landmarks rock, and how easy they are to use on your site</a> in the README on GitHub.</p>
 			<p>You can learn about <a href="https://github.com/matatk/landmarks#this-extensions-support-for-landmarks">this extension's support for the landmarks standards</a> in the README on GitHub.</p>
 		</details>
-		<details id="section-devtools" open>
+		<details open>
 			<summary><h2>Inspecting landmarks in the DOM</h2></summary>
 			<p>A Developer Tools panel called “Landmarks” is also provided. This can be used in the same way as the pop-up above, but also allows you to visit each landmark element in the DOM inspector, using inspection buttons that are placed immediately after the button for each landmark.</p> <p>This feature is primarily intended for web authors/developers and accessibility testers.</p>
 		</details>
-		<details id="section-development" open>
-			<summary><h2>Landmarks extension development info</h2></summary>
+		<details open>
+			<summary><h2>Landmarks extension development information</h2></summary>
 			<p>Check out the <a href="https://github.com/matatk/landmarks#development">Development</a> section of the README on GitHub.</p>
 		</details>
 		</main>

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -8,6 +8,7 @@
 	<body>
 		<header>
 			<h1>Landmarks Help</h1>
+			<p>If you need support, please <a href="https://github.com/matatk/landmarks/issues">check the known issues for Landmarks</a> and, if necessary, file a new issue using the "New Issue" button on that page.</p>
 		</header>
 		<main>
 		<details id="section-new" open>

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -12,7 +12,8 @@
 		<main>
 		<details open>
 			<summary><h2>What's New?</h2></summary>
-			<p>FIXME TODO</p>
+			<p>New in version <span id="version"></span>&hellip;</p>
+			<p><mark>FIXME TODO</mark></p>
 		</details>
 		<details id="keyboard-shortcuts" open>
 			<summary><h2>Keyboard shortcuts</h2></summary>

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -20,9 +20,7 @@
 		<details open>
 			<summary><h2>Navigation</h2></summary>
 			<h3>Shortcut Keys</h3>
-			<p>You can use shortcut keys to navigate between landmarks, as detailed above.</p>
-			<p>When you do, landmarks will be focused, and a border shown according to your <a href="#border-preferences">border preferences</a>.</p>
-			<p>You can change the keyboard shortcuts in the following browsers.</p>
+			<p>You can use shortcut keys to navigate between landmarks, as detailed above. When you do, landmarks will be focused, and a border shown according to your <a href="#border-preferences">border preferences</a>. You can change the keyboard shortcuts in the following browsers.</p>
 			<ul>
 				<li><strong>Chrome:</strong> More ⋮ → Settings → Extensions [on the left-hand side] → Keyboard shortcuts [at the bottom of the page]</li>
 				<li><strong>Opera:</strong> Opera Menu / Speed Dial → Extensions → Extension Keyboard Shortcuts</li>

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -15,21 +15,20 @@
 			<p>New in version <span id="version"></span>&hellip;</p>
 			<p><mark>FIXME TODO</mark></p>
 		</details>
-		<details id="keyboard-shortcuts" open>
-			<summary><h2>Keyboard shortcuts</h2></summary>
-		</details>
 		<details open>
-			<summary><h2>Navigation</h2></summary>
-			<h3>Shortcut Keys</h3>
-			<p>You can use shortcut keys to navigate between landmarks, as detailed above. When you do, landmarks will be focused, and a border shown according to your <a href="#border-preferences">border preferences</a>.</p>
-			<p id="shortcuts-link-container"></p>
+			<summary><h2>Keyboard Navigation</h2></summary>
+			<p>You can use shortcut keys to navigate between landmarks, as detailed below. When you do, landmarks will be focused, and a border shown according to your <a href="#border-preferences">border preferences</a>.</p>
+			<div id="keyboard-shortcuts"></div>
+			<p data-container="shortcuts"></p>
 			<p>You can also change the keyboard shortcuts in the following browsers.</p>
 			<ul>
 				<li><strong>Chrome:</strong> More ⋮ → Settings → Extensions [on the left-hand side] → Keyboard shortcuts [at the bottom of the page]</li>
 				<li><strong>Opera:</strong> Opera Menu / Speed Dial → Extensions → Extension Keyboard Shortcuts</li>
 			</ul>
-			<h3>Toolbar Pop-up</h3>
-			<p>If landmarks are found on the page, the Landmarks button in the toolbar (which looks like an “L”) will be badged with the number of landmarks found.</p>
+		</details>
+		<details open>
+			<summary><h2>Toolbar Pop-up</h2></summary>
+			<p>If landmarks are found on the page, the Landmarks button in the toolbar (which looks like an "L") will be badged with the number of landmarks found. You can use the pop-up as follows.</p>
 			<ol>
 				<li>
 					<p>Activate the Landmarks toolbar button. A pop-up will appear. If landmarks are present on the page, they will be shown in a nested list, reflecting the structure of the landmarks on the page.</p>
@@ -41,8 +40,16 @@
 					<p>To close the pop-up, press <kbd>Escape</kbd>, or click outside of the pop-up.</p>
 				</li>
 			</ol>
-			<h3>Inspecting landmarks in the DOM</h3>
-			<p>A Developer Tools panel called “Landmarks” is also provided. This can be used in the same way as the pop-up above, but also allows you to visit each landmark element in the DOM inspector, using inspection buttons that are placed immediately after the button for each landmark.</p> <p>This feature is primarily intended for web authors/developers and accessibility testers.</p>
+		</details>
+		<details open>
+			<summary><h2>Sidebar</h2></summary>
+			<p>On Firefox and Opera, you can also explore landmarks on the page by way of a sidebar. You can choose in the preferences whether you'd like to use both the toolbar pop-up and sidebar, or just the sidebar.</p>
+			<p data-container="settings"></p>
+			<p>You can also get to the extension’s settings as follows.</p>
+			<ul>
+				<li><strong>Firefox:</strong> Menu ☰ → Add-ons → Extensions [on left-hand side, if not already activated] → Preferences [under Landmarks, then scroll down]</li>
+				<li><strong>Chrome/Opera:</strong> Right-click on, or activate the context menu of, the Landmarks button in the toolbar → Options</li>
+			</ul>
 		</details>
 		<details open>
 			<summary><h2 id="border-preferences">Preferences</h2></summary>
@@ -58,7 +65,7 @@
 				<li><strong>The border’s colour.</strong></li>
 				<li><strong>The font size used in the landmark label.</strong></li>
 			</ul>
-			<p id="settings-link-container"></p>
+			<p data-container="settings"></p>
 			<p>You can also get to the extension’s settings as follows.</p>
 			<ul>
 				<li><strong>Firefox:</strong> Menu ☰ → Add-ons → Extensions [on left-hand side, if not already activated] → Preferences [under Landmarks, then scroll down]</li>
@@ -69,6 +76,10 @@
 			<summary><h2>Info for web authors and developers</h2></summary>
 			<p>You can learn about <a href="https://github.com/matatk/landmarks#information-for-web-authors-designers-and-developers">why landmarks rock, and how easy they are to use on your site</a> in the README on GitHub.</p>
 			<p>You can learn about <a href="https://github.com/matatk/landmarks#this-extensions-support-for-landmarks">this extension's support for the landmarks standards</a> in the README on GitHub.</p>
+		</details>
+		<details open>
+			<summary><h2>Inspecting landmarks in the DOM</h2></summary>
+			<p>A Developer Tools panel called “Landmarks” is also provided. This can be used in the same way as the pop-up above, but also allows you to visit each landmark element in the DOM inspector, using inspection buttons that are placed immediately after the button for each landmark.</p> <p>This feature is primarily intended for web authors/developers and accessibility testers.</p>
 		</details>
 		<details open>
 			<summary><h2>Landmarks extension development info</h2></summary>

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -50,6 +50,9 @@
 				<input id="debug-info" type="checkbox">
 				<label for="debug-info" data-message="prefsDebugInfo"></label>
 			</div>
+			<div class="input-first">
+				<button id="reset-all" data-message="prefsResetAll" class="browser-style"></button>
+			</div>
 		</details>
 
 		<script src="options.js"></script>

--- a/src/static/splash.css
+++ b/src/static/splash.css
@@ -1,5 +1,0 @@
-td.error {
-	background-color: #d00;
-	color: white;
-	font-weight: bold;
-}


### PR DESCRIPTION
Add a new, HTML help page that explains how to use the extension, including reflecting keyboard shortcuts and providing links to go directly to the settings, for convenience.

This was created by moving some content from the README and the techniques from the original “splash” content script. It also directly imports the main Landmarks content script so that the extension can itself be used to navigate this page. Refer to #165 for the details.

Partly addresses #165 (provides the foundation for managing the keyboard shortcuts when another one is added).