### PR TITLE
Home page links and ease-of-use

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
 			<p>Landmark regions broadly signpost the areas of a page (e.g. navigation, search, main content and so on). This extension allows you to navigate a web page via its landmarks, <strong>if they've been provided by its author</strong>, using the keyboard or a pop-up menu.</p>
 		</section>
 		<section class="install">
+			<!-- This section is repeated below. -->
 			<ul>
 				<li>
 					<a href="https://addons.mozilla.org/addon/landmarks/">Firefox add&#8209;on</a>
@@ -57,7 +58,7 @@
 		</section>
 		<section class="feature">
 			<div>
-				<h2>Explore Landmarks via pop-up</h2>
+				<h2>Explore landmarks via pop-up</h2>
 				<p>The pop-up shows landmark regions found on the page, and can be accessed via mouse or keyboard.</p>
 			</div>
 			<div>
@@ -66,7 +67,7 @@
 		</section>
 		<section class="feature">
 			<div>
-				<h2>Explore Landmarks via keyboard</h2>
+				<h2>Explore landmarks via keyboard</h2>
 				<p>Landmarks are scrolled into view, focused and highlighted, with their label shown.</p>
 				<p>You can change how long the border appears, its colour and the font size.</p>
 				<p>Keyboard shortcuts allow you to move between landmarks directly, and you can also change these shortcuts if you're using Chrome or Opera.</p>
@@ -77,7 +78,7 @@
 		</section>
 		<section class="feature">
 			<div>
-				<h2>Explore Landmarks via sidebar</h2>
+				<h2>Explore landmarks via sidebar</h2>
 				<p>Firefox and Opera support sidebars, and you can opt for landmark regions to be shown here, too.</p>
 			</div>
 			<div>
@@ -93,6 +94,34 @@
 				<img src="meta/firefox-4.png" alt="">
 				<img src="meta/firefox-5.png" alt="">
 			</div>
+		</section>
+		<section class="further-info">
+			<h2>Further information</h2>
+			<ul>
+				<li>
+					<p><a href="https://github.com/matatk/landmarks#information-for-web-authors-designers-and-developers">Why landmarks rock, and how to easily provide them on your site</a>.</p>
+				</li>
+				<li>
+					<p><a href="https://github.com/matatk/landmarks#this-extensions-support-for-landmarks">This extension's support for the landmarks standards</a>.</p>
+				</li>
+				<li>
+					<p><a href="https://github.com/matatk/landmarks#development">Landmarks extension development information</a>.</p>
+				</li>
+			</ul>
+		</section>
+		<section class="install">
+			<!-- This section is repeated above. -->
+			<ul>
+				<li>
+					<a href="https://addons.mozilla.org/addon/landmarks/">Firefox add&#8209;on</a>
+				</li>
+				<li>
+					<a href="https://chrome.google.com/webstore/detail/landmark-navigation-via-k/ddpokpbjopmeeiiolheejjpkonlkklgp">Chrome extension</a>
+				</li>
+				<li>
+					<a href="https://addons.opera.com/en-gb/extensions/details/landmarks/">Opera extension</a><br>(May not be the latest version, due to review times.)
+				</li>
+			</ul>
 		</section>
 		</main>
 		<footer>

--- a/landmarks.css
+++ b/landmarks.css
@@ -60,6 +60,11 @@ img:nth-of-type(2) { padding-top: 2em; }
 section.install a { color: var(--words); }
 footer a { color: var(--words); }
 
+section.further-info {
+	margin-top: 2em;
+	background-color: #eee;
+}
+
 @media screen and (min-width: 45em) {
 	header { padding: 5vw; }
 
@@ -81,6 +86,11 @@ footer a { color: var(--words); }
 
 	section.feature:nth-child(odd) { flex-direction: row; }
 	section.feature:nth-child(even) { flex-direction: row-reverse; }
+
+	section.further-info {
+		padding-left: 15%;
+		padding-right: 15%;
+	}
 }
 
 @media screen and (min-width: 65em) {


### PR DESCRIPTION
* Provide links to the extra info in the README, like the bundled help
page does.
* Use sentence case for the headings, for consistency with the help page
and README.
* Repeat the installation links at the end of the page.