### PR TITLE
feat(toggle): Show all landmarks keyboard shortcut

### DIFF
--- a/src/assemble/manifest.common.json
+++ b/src/assemble/manifest.common.json
@@ -28,6 +28,9 @@
   ],
 
   "commands": {
+    "toggle-all-landmarks": {
+      "description": "__MSG_toggleAllShortcutDescription__"
+    },
     "main-landmark": {
       "suggested_key": {
         "default": "Alt+Shift+M"

--- a/src/assemble/manifest.firefox.json
+++ b/src/assemble/manifest.firefox.json
@@ -34,5 +34,13 @@
     }
   },
 
-  "devtools_page": "devtools.html"
+  "devtools_page": "devtools.html",
+
+  "commands": {
+    "toggle-all-landmarks": {
+      "suggested_key": {
+        "default": "Alt+Shift+A"
+      }
+    }
+  }
 }

--- a/src/assemble/manifest.firefox.json
+++ b/src/assemble/manifest.firefox.json
@@ -39,7 +39,7 @@
   "commands": {
     "toggle-all-landmarks": {
       "suggested_key": {
-        "default": "Alt+Shift+A"
+        "default": "Alt+Shift+S"
       }
     }
   }

--- a/src/assemble/messages.common.json
+++ b/src/assemble/messages.common.json
@@ -26,6 +26,10 @@
     "message": "Move to and highlight the main landmark"
   },
 
+  "toggleAllShortcutDescription": {
+    "message": "Toggle the display of all landmarks on the page"
+  },
+
   "noMainLandmarkFound": {
     "message": "No main landmark found"
   },

--- a/src/assemble/messages.common.json
+++ b/src/assemble/messages.common.json
@@ -96,7 +96,7 @@
   },
 
   "prefsResetAll": {
-    "message": "Reset everything to defaults"
+    "message": "Reset settings to defaults"
   },
 
 

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -5,7 +5,7 @@ import { defaultInterfaceSettings } from './defaults'
 import disconnectingPortErrorCheck from './disconnectingPortErrorCheck'
 import Logger from './logger'
 
-const logger = new Logger()
+const logger = new Logger(window)
 
 const contentConnections = {}
 const devtoolsConnections = {}

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -296,6 +296,7 @@ browser.commands.onCommand.addListener(function(command) {
 		case 'next-landmark':
 		case 'prev-landmark':
 		case 'main-landmark':
+		case 'toggle-all-landmarks':
 			sendToActiveContentScriptIfExists({ name: command })
 			break
 		default:

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -82,6 +82,7 @@ function messageHandler(message, sendingPort) {
 			// landmarks again when asked.
 			logger.log('Landmarks: refresh triggered')
 			elementFocuser.clear()
+			borderDrawer.removeAllBorders()
 			findLandmarksAndUpdateBackgroundScript()
 			break
 		default:

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -16,6 +16,7 @@ const pauseHandler = new PauseHandler(logger)
 const outOfDateTime = 2000
 let observer = null
 let port = null
+let showingAllBorders = false
 
 
 //
@@ -55,7 +56,7 @@ function messageHandler(message, sendingPort) {
 			handleOutdatedResults()
 			const mainElementInfo = landmarksFinder.getMainElementRoleLabel()
 			if (mainElementInfo) {
-				elementFocuser.focusElement(mainElementInfo)
+				elementFocuser.focusElement(mainElementInfo, !showingAllBorders)
 			} else {
 				alert(browser.i18n.getMessage('noMainLandmarkFound') + '.')
 			}
@@ -64,8 +65,15 @@ function messageHandler(message, sendingPort) {
 		case 'toggle-all-landmarks':
 			// Triggered by keyboard shortcut
 			handleOutdatedResults()
-			borderDrawer.addBorderToElements(
-				landmarksFinder.allElementsRolesLabels())
+			if (!showingAllBorders) {
+				elementFocuser.clearRemovalTimer()
+				borderDrawer.addBorderToElements(
+					landmarksFinder.allElementsRolesLabels())
+				showingAllBorders = true
+			} else {
+				borderDrawer.removeAllBorders()
+				showingAllBorders = false
+			}
 			break
 		case 'trigger-refresh':
 			// On sites that use single-page style techniques to transition
@@ -96,7 +104,8 @@ function checkFocusElement(callbackReturningElementInfo) {
 		return
 	}
 
-	elementFocuser.focusElement(callbackReturningElementInfo())
+	elementFocuser.focusElement(
+		callbackReturningElementInfo(), !showingAllBorders)
 }
 
 
@@ -113,7 +122,9 @@ function findLandmarksAndUpdateBackgroundScript() {
 	})
 	elementFocuser.refreshFocusedElement()
 	borderDrawer.refreshBorders()
-	// TODO check here if we need to add/remove toggled all landmark borders
+	if (showingAllBorders) {
+		borderDrawer.addBorderToElements(landmarksFinder.allElementsRolesLabels)
+	}
 }
 
 

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -6,7 +6,7 @@ import Logger from './logger'
 import BorderManager from './borderManager'
 import ContrastChecker from './contrastChecker'
 
-const logger = new Logger()
+const logger = new Logger(window)
 const landmarksFinder = new LandmarksFinder(window, document)
 const contrastChecker = new ContrastChecker()
 const borderManager = new BorderManager(window, document, contrastChecker)

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -53,6 +53,10 @@ function messageHandler(message, sendingPort) {
 			}
 			break
 		}
+		case 'toggle-all-landmarks':
+			// Triggered by keyboard shortcut
+			alert('toggle all landmarks')
+			break
 		case 'trigger-refresh':
 			// On sites that use single-page style techniques to transition
 			// (such as YouTube and GitHub) we monitor in the background script

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -16,7 +16,6 @@ const pauseHandler = new PauseHandler(logger)
 const outOfDateTime = 2000
 let observer = null
 let port = null
-let showingAllBorders = false
 
 
 //
@@ -56,7 +55,7 @@ function messageHandler(message, sendingPort) {
 			handleOutdatedResults()
 			const mainElementInfo = landmarksFinder.getMainElementRoleLabel()
 			if (mainElementInfo) {
-				elementFocuser.focusElement(mainElementInfo, !showingAllBorders)
+				elementFocuser.focusElement(mainElementInfo)
 			} else {
 				alert(browser.i18n.getMessage('noMainLandmarkFound') + '.')
 			}
@@ -65,14 +64,13 @@ function messageHandler(message, sendingPort) {
 		case 'toggle-all-landmarks':
 			// Triggered by keyboard shortcut
 			handleOutdatedResults()
-			if (!showingAllBorders) {
-				elementFocuser.clearBorderRemovalTimer()
+			if (elementFocuser.isManagingBorders()) {
+				elementFocuser.manageBorders(false)
 				borderDrawer.addBorderToElements(
 					landmarksFinder.allElementsRolesLabels())
-				showingAllBorders = true
 			} else {
 				borderDrawer.removeAllBorders()
-				showingAllBorders = false
+				elementFocuser.manageBorders(true)
 			}
 			break
 		case 'trigger-refresh':
@@ -104,8 +102,7 @@ function checkFocusElement(callbackReturningElementInfo) {
 		return
 	}
 
-	elementFocuser.focusElement(
-		callbackReturningElementInfo(), !showingAllBorders)
+	elementFocuser.focusElement(callbackReturningElementInfo())
 }
 
 
@@ -122,7 +119,7 @@ function findLandmarksAndUpdateBackgroundScript() {
 	})
 	elementFocuser.refreshFocusedElement()
 	borderDrawer.refreshBorders()
-	if (showingAllBorders) {
+	if (!elementFocuser.isManagingBorders()) {
 		borderDrawer.addBorderToElements(landmarksFinder.allElementsRolesLabels)
 	}
 }

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -64,7 +64,7 @@ function messageHandler(message, sendingPort) {
 		case 'toggle-all-landmarks':
 			// Triggered by keyboard shortcut
 			handleOutdatedResults()
-			elementFocuser.addBorderToElements(
+			borderManager.addBorderToElements(
 				landmarksFinder.allElementsRolesLabels())
 			break
 		case 'trigger-refresh':
@@ -157,7 +157,7 @@ function setUpMutationObserver() {
 		// (which happens in e.g. Google Docs)
 		pauseHandler.run(
 			// Ignore mutations if Landmarks caused them
-			elementFocuser.didJustMakeChanges,
+			borderManager.didJustMakeChanges,
 			function() {
 				if (shouldRefreshLandmarkss(mutations)) {
 					logger.log('Scan due to mutation')

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -29,7 +29,7 @@ function messageHandler(message, sendingPort) {
 			handleOutdatedResults()
 			sendingPort.postMessage({
 				name: 'landmarks',
-				data: landmarksFinder.filter()
+				data: landmarksFinder.allDepthsRolesLabelsSelectors()
 			})
 			break
 		case 'focus-landmark':
@@ -107,7 +107,10 @@ function checkFocusElement(callbackReturningElementInfo) {
 function findLandmarksAndUpdateBackgroundScript() {
 	logger.timeStamp('findLandmarksAndUpdateBackgroundScript()')
 	landmarksFinder.find()
-	port.postMessage({ name: 'landmarks', data: landmarksFinder.filter() })
+	port.postMessage({
+		name: 'landmarks',
+		data: landmarksFinder.allDepthsRolesLabelsSelectors()
+	})
 	elementFocuser.refreshFocusedElement()
 	borderDrawer.refreshBorders()
 	// TODO check here if we need to add/remove toggled all landmark borders

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -55,7 +55,8 @@ function messageHandler(message, sendingPort) {
 		}
 		case 'toggle-all-landmarks':
 			// Triggered by keyboard shortcut
-			alert('toggle all landmarks')
+			handleOutdatedResults()
+			ef.addBorderToElements(lf.allElementsRolesLabels())
 			break
 		case 'trigger-refresh':
 			// On sites that use single-page style techniques to transition
@@ -99,6 +100,7 @@ function findLandmarksAndUpdateBackgroundScript() {
 	lf.find()
 	port.postMessage({ name: 'landmarks', data: lf.filter() })
 	ef.checkFocusedElement()
+	// TODO check here if we need to add/remove toggled all landmark borders
 }
 
 

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -157,7 +157,7 @@ function setUpMutationObserver() {
 		// (which happens in e.g. Google Docs)
 		pauseHandler.run(
 			// Ignore mutations if Landmarks caused them
-			borderDrawer.didJustMakeChanges,
+			borderDrawer.hasMadeDOMChanges,
 			function() {
 				if (shouldRefreshLandmarkss(mutations)) {
 					logger.log('Scan due to mutation')

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -108,8 +108,8 @@ function findLandmarksAndUpdateBackgroundScript() {
 	logger.timeStamp('findLandmarksAndUpdateBackgroundScript()')
 	landmarksFinder.find()
 	port.postMessage({ name: 'landmarks', data: landmarksFinder.filter() })
-	elementFocuser.updateFocusedElement()
-	borderDrawer.updateBorders()
+	elementFocuser.refreshFocusedElement()
+	borderDrawer.refreshBorders()
 	// TODO check here if we need to add/remove toggled all landmark borders
 }
 

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -66,7 +66,7 @@ function messageHandler(message, sendingPort) {
 			// Triggered by keyboard shortcut
 			handleOutdatedResults()
 			if (!showingAllBorders) {
-				elementFocuser.clearRemovalTimer()
+				elementFocuser.clearBorderRemovalTimer()
 				borderDrawer.addBorderToElements(
 					landmarksFinder.allElementsRolesLabels())
 				showingAllBorders = true
@@ -83,7 +83,7 @@ function messageHandler(message, sendingPort) {
 			// this happens, we should treat it as a new page, and fetch
 			// landmarks again when asked.
 			logger.log('Landmarks: refresh triggered')
-			elementFocuser.removeBorderOnCurrentlySelectedElement()
+			elementFocuser.clear()
 			findLandmarksAndUpdateBackgroundScript()
 			break
 		default:

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -3,14 +3,14 @@ import LandmarksFinder from './landmarksFinder'
 import ElementFocuser from './elementFocuser'
 import PauseHandler from './pauseHandler'
 import Logger from './logger'
-import BorderManager from './borderManager'
+import BorderDrawer from './borderDrawer'
 import ContrastChecker from './contrastChecker'
 
 const logger = new Logger(window)
 const landmarksFinder = new LandmarksFinder(window, document)
 const contrastChecker = new ContrastChecker()
-const borderManager = new BorderManager(window, document, contrastChecker)
-const elementFocuser = new ElementFocuser(document, borderManager)
+const borderDrawer = new BorderDrawer(window, document, contrastChecker)
+const elementFocuser = new ElementFocuser(document, borderDrawer)
 const pauseHandler = new PauseHandler(logger)
 
 const outOfDateTime = 2000
@@ -64,7 +64,7 @@ function messageHandler(message, sendingPort) {
 		case 'toggle-all-landmarks':
 			// Triggered by keyboard shortcut
 			handleOutdatedResults()
-			borderManager.addBorderToElements(
+			borderDrawer.addBorderToElements(
 				landmarksFinder.allElementsRolesLabels())
 			break
 		case 'trigger-refresh':
@@ -157,7 +157,7 @@ function setUpMutationObserver() {
 		// (which happens in e.g. Google Docs)
 		pauseHandler.run(
 			// Ignore mutations if Landmarks caused them
-			borderManager.didJustMakeChanges,
+			borderDrawer.didJustMakeChanges,
 			function() {
 				if (shouldRefreshLandmarkss(mutations)) {
 					logger.log('Scan due to mutation')

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -108,7 +108,8 @@ function findLandmarksAndUpdateBackgroundScript() {
 	logger.timeStamp('findLandmarksAndUpdateBackgroundScript()')
 	landmarksFinder.find()
 	port.postMessage({ name: 'landmarks', data: landmarksFinder.filter() })
-	elementFocuser.checkFocusedElement()
+	elementFocuser.updateFocusedElement()
+	borderDrawer.updateBorders()
 	// TODO check here if we need to add/remove toggled all landmark borders
 }
 

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -120,7 +120,8 @@ function findLandmarksAndUpdateBackgroundScript() {
 	elementFocuser.refreshFocusedElement()
 	borderDrawer.refreshBorders()
 	if (!elementFocuser.isManagingBorders()) {
-		borderDrawer.addBorderToElements(landmarksFinder.allElementsRolesLabels)
+		borderDrawer.addBorderToElements(
+			landmarksFinder.allElementsRolesLabels())
 	}
 }
 

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -229,7 +229,8 @@ if (INTERFACE === 'sidebar') {
 
 	browser.storage.onChanged.addListener(function(changes) {
 		// What if the sidebar is open and the user changes their preference?
-		if (changes.hasOwnProperty('interface')) {
+		if (changes.hasOwnProperty('interface')
+			&& changes.interface.newValue !== changes.interface.oldValue) {
 			switch (changes.interface.newValue) {
 				case 'sidebar': removeNote()
 					break

--- a/src/code/_help.js
+++ b/src/code/_help.js
@@ -210,7 +210,8 @@ function reflectInstallOrUpdate() {
 
 function allowLinksToOpenSections() {
 	for (const link of document.querySelectorAll('a[href]')) {
-		if (link.getAttribute('href').startsWith('#')) {
+		const href = link.getAttribute('href')
+		if (href.length > 1 && href.startsWith('#')) {
 			link.onclick = function() {
 				document.querySelector(this.getAttribute('href')).open = true
 			}

--- a/src/code/_help.js
+++ b/src/code/_help.js
@@ -14,32 +14,30 @@ const shortcutTableRows = [
 ]
 
 const keyboardShortcutsLink = {
-	element: 'p', contains: [{
-		element: 'a',
-		class: 'config',
-		tabindex: 0,
-		content: 'Add or change shortcuts',
-		listen: [{
-			event: 'click',
-			handler: () => port.postMessage({
-				name: 'splash-open-configure-shortcuts'
-			})
-		}, {
-			event: 'keydown',
-			handler: (event) => {
-				if (event.key === 'Enter') {
-					port.postMessage({
-						name: 'splash-open-configure-shortcuts'
-					})
-				}
+	element: 'a',
+	class: 'configAction',
+	tabindex: 0,
+	content: 'Add or change shortcuts',
+	listen: [{
+		event: 'click',
+		handler: () => port.postMessage({
+			name: 'splash-open-configure-shortcuts'
+		})
+	}, {
+		event: 'keydown',
+		handler: (event) => {
+			if (event.key === 'Enter') {
+				port.postMessage({
+					name: 'splash-open-configure-shortcuts'
+				})
 			}
-		}]
+		}
 	}]
 }
 
 const settingsLink = {
 	element: 'a',
-	class: 'config',
+	class: 'configAction',
 	tabindex: 0,
 	content: 'Change preferences (opens in new tab)',
 	listen: [{
@@ -131,7 +129,7 @@ function addCommandRowAndReportIfMissing(command) {
 			}
 		}
 	} else {
-		shortcutCellElement = { element: 'td', class: 'error', contains: [
+		shortcutCellElement = { element: 'td', class: 'errorItem', contains: [
 			{ text: 'Not set up' }
 		]}
 		shortcutNotSet = true
@@ -189,12 +187,17 @@ function messageHandler(message) {  // also sendingPort
 		document.getElementById('keyboard-shortcuts-table'))
 
 	if (shortcutNotSet) {
-		// TODO does this appear on Firefox?
 		document.querySelector('#section-keyboard-navigation summary')
-			.classList.add('error')
+			.classList.add('errorItem')
+
+		document.querySelector('[data-link="shortcuts"] a')
+			.classList.add('errorAction')
+
 		for (const warning of document.querySelectorAll('[data-warning]')) {
 			warning.style.display = 'block'
 		}
+
+		document.getElementById('symbol').style.display = 'inline'
 	}
 }
 
@@ -251,8 +254,8 @@ function main() {
 	port.onMessage.addListener(messageHandler)
 	port.postMessage({ name: 'get-commands' })
 
-	if (BROWSER === 'firefox' || BROWSER === 'opera') {
-		document.getElementById('section-sidebar').open = true
+	if (BROWSER !== 'firefox' && BROWSER !== 'opera') {
+		document.getElementById('section-sidebar').open = false
 	}
 
 	makeSettingsAndShortcutsLinks()

--- a/src/code/_help.js
+++ b/src/code/_help.js
@@ -1,6 +1,7 @@
 import disconnectingPortErrorCheck from './disconnectingPortErrorCheck'
 
 let port
+let shortcutNotSet = false
 
 // FIXME global
 const shortcutTableRows = [
@@ -117,6 +118,7 @@ function addCommandRowAndReportIfMissing(command) {
 		shortcutCellElement = { element: 'td', class: 'error', contains: [
 			{ text: 'Not set up' }
 		]}
+		shortcutNotSet = true
 	}
 
 	shortcutTableRows.push({
@@ -169,6 +171,15 @@ function messageHandler(message) {  // also sendingPort
 
 	makeHTML({ element: 'table', contains: shortcutTableRows },
 		document.getElementById('keyboard-shortcuts-table'))
+
+	if (shortcutNotSet) {
+		// TODO does this appear on Firefox?
+		document.querySelector('#section-keyboard-navigation summary')
+			.classList.add('error')
+		for (const warning of document.querySelectorAll('[data-warning]')) {
+			warning.style.display = 'block'
+		}
+	}
 }
 
 function makeConfigLinks(type, template) {

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -66,7 +66,7 @@ function setUpOptionHandlers() {
 		document.getElementById('reset-messages').onclick = resetMessages
 	}
 
-	document.getElementById('reset-all').onclick = resetAll
+	document.getElementById('reset-to-defaults').onclick = resetToDefaults
 }
 
 function interfaceExplainer() {
@@ -113,9 +113,12 @@ function dismissalStateChanged(thingChanged) {
 	return dismissalStates.hasOwnProperty(thingChanged)
 }
 
-function resetAll() {
-	browser.storage.sync.clear()
-	window.location.reload()
+function resetToDefaults() {
+	browser.storage.sync.set(defaultSettings, function() {
+		window.location.reload()
+	})
+	// Note: Can't use use .clear() as that removes everything, which would
+	//       cause problems for currently-visible borders.
 }
 
 function main() {

--- a/src/code/borderDrawer.js
+++ b/src/code/borderDrawer.js
@@ -64,6 +64,10 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 	//
 	// { element: HTMLElement, role: <string>, label: <string> }
 	this.addBorder = function(elementInfo) {
+		// FIXME if page was changed and new elements are added and we want to
+		// just add those, the best way woudl be if this could cope with that.
+		// Do we assume that the label of an element wouldn't change after a
+		// page mutation? If so then the next line is fine.
 		if (!borderedElements.has(elementInfo.element)) {  // FIXME pers - togg
 			drawBorderAndLabel(
 				elementInfo.element,

--- a/src/code/borderDrawer.js
+++ b/src/code/borderDrawer.js
@@ -63,12 +63,13 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 	// object, as returned by the various LandmarksFinder functions.
 	//
 	// { element: HTMLElement, role: <string>, label: <string> }
+	//
+	// Note: we assume that if an element already exists and we try to add it
+	//       again (as may happen if the page changes whilst we're displaying
+	//       all elements, and try to add any new ones) that the existing
+	//       elements' labels won't have changed.
 	this.addBorder = function(elementInfo) {
-		// FIXME if page was changed and new elements are added and we want to
-		// just add those, the best way woudl be if this could cope with that.
-		// Do we assume that the label of an element wouldn't change after a
-		// page mutation? If so then the next line is fine.
-		if (!borderedElements.has(elementInfo.element)) {  // FIXME pers - togg
+		if (!borderedElements.has(elementInfo.element)) {
 			drawBorderAndLabel(
 				elementInfo.element,
 				landmarkName(elementInfo),
@@ -86,9 +87,15 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 		}
 	}
 
-	// Attempt to remove border from an element.
 	this.removeBorderOn = function(element) {
 		if (borderedElements.has(element)) {
+			deleteBorderAndLabelDivs(element)
+			borderedElements.delete(element)
+		}
+	}
+
+	this.removeAllBorders = function() {
+		for (const element of borderedElements.keys()) {
 			deleteBorderAndLabelDivs(element)
 			borderedElements.delete(element)
 		}
@@ -104,7 +111,6 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 
 	// In case it's detected that an element may've moved due to mutations
 	// FIXME should this handle elements being removed due to mutations?
-	// FIXME what about elements being added (no, that seems beyond scope)?
 	this.refreshBorders = function() {
 		resizeHandler()
 	}

--- a/src/code/borderDrawer.js
+++ b/src/code/borderDrawer.js
@@ -17,7 +17,11 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 
 	function resizeHandler() {
 		for (const [element, related] of borderedElements) {
-			sizeBorderAndLabel(element, related.border, related.label)
+			if (doc.body.contains(element)) {
+				sizeBorderAndLabel(element, related.border, related.label)
+			} else {
+				removeBorderAndDelete(element)
+			}
 		}
 	}
 
@@ -89,15 +93,13 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 
 	this.removeBorderOn = function(element) {
 		if (borderedElements.has(element)) {
-			deleteBorderAndLabelDivs(element)
-			borderedElements.delete(element)
+			removeBorderAndDelete(element)
 		}
 	}
 
 	this.removeAllBorders = function() {
 		for (const element of borderedElements.keys()) {
-			deleteBorderAndLabelDivs(element)
-			borderedElements.delete(element)
+			removeBorderAndDelete(element)
 		}
 	}
 
@@ -110,7 +112,6 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 	}
 
 	// In case it's detected that an element may've moved due to mutations
-	// FIXME should this handle elements being removed due to mutations?
 	this.refreshBorders = function() {
 		resizeHandler()
 	}
@@ -201,10 +202,16 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 		madeDOMChanges = true  // seems to be in the right place
 	}
 
+	function removeBorderAndDelete(element) {
+		removeBorderAndLabelFor(element)
+		borderedElements.delete(element)
+	}
+
 	// Remove known-existing DOM nodes for the border and label
 	// Note: does not remove the record of the element, so as to avoid an
 	//       infinite loop when redrawing borders.
-	function deleteBorderAndLabelDivs(element) {
+	//       TODO fix this with .keys()?
+	function removeBorderAndLabelFor(element) {
 		const related = borderedElements.get(element)
 		related.border.remove()
 		related.label.remove()
@@ -222,7 +229,7 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 	function redrawBordersAndLabels() {
 		for (const [element, related] of borderedElements) {
 			const labelText = related.label.innerText
-			deleteBorderAndLabelDivs(element)
+			removeBorderAndLabelFor(element)
 			drawBorderAndLabel(
 				element,
 				labelText,

--- a/src/code/borderDrawer.js
+++ b/src/code/borderDrawer.js
@@ -8,7 +8,7 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 	let borderColour = defaultBorderSettings.borderColour      // cached locally
 	let borderFontSize = defaultBorderSettings.borderFontSize  // cached locally
 	let labelFontColour = null  // computed based on border colour
-	let justMadeChanges = false
+	let madeDOMChanges = false
 
 
 	//
@@ -93,13 +93,15 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 	// Did we just make changes to a border? If so, report this, so that the
 	// mutation observer can ignore it.
 	this.hasMadeDOMChanges = function() {
-		const didChanges = justMadeChanges
-		justMadeChanges = false
+		const didChanges = madeDOMChanges
+		madeDOMChanges = false
 		return didChanges
 	}
 
 	// In case it's detected that an element may've moved due to mutations
-	this.runResizeHandlers = function() {
+	// FIXME should this handle elements being removed due to mutations?
+	// FIXME what about elements being added (no, that seems beyond scope)?
+	this.updateBorders = function() {
 		resizeHandler()
 	}
 
@@ -147,7 +149,7 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 
 		doc.body.appendChild(borderDiv)
 		doc.body.appendChild(labelDiv)
-		justMadeChanges = true  // seems to be covered by sizeBorderAndLabel()
+		madeDOMChanges = true  // seems to be covered by sizeBorderAndLabel()
 		sizeBorderAndLabel(element, borderDiv, labelDiv)
 
 		borderedElements.set(element, { border: borderDiv, label: labelDiv })
@@ -186,7 +188,7 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 			label.style.left = elementLeftEdgeStyle
 		}
 
-		justMadeChanges = true  // seems to be in the right place
+		madeDOMChanges = true  // seems to be in the right place
 	}
 
 	// Remove known-existing DOM nodes for the border and label
@@ -196,7 +198,7 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 		const related = borderedElements.get(element)
 		related.border.remove()
 		related.label.remove()
-		justMadeChanges = true
+		madeDOMChanges = true
 	}
 
 	// Work out if the label font colour should be black or white

--- a/src/code/borderDrawer.js
+++ b/src/code/borderDrawer.js
@@ -1,7 +1,7 @@
 import landmarkName from './landmarkName'
 import { defaultBorderSettings } from './defaults'
 
-export default function BorderManager(win, doc, contrastChecker) {
+export default function BorderDrawer(win, doc, contrastChecker) {
 	const borderWidthPx = 4
 
 	const borderedElements = new Map()

--- a/src/code/borderDrawer.js
+++ b/src/code/borderDrawer.js
@@ -66,7 +66,7 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 	// Add the landmark border and label for an element. Takes an element info
 	// object, as returned by the various LandmarksFinder functions.
 	//
-	// { element: HTMLElement, role: <string>, label: <string> }
+	// { element: <HTMLElement>, role: <string>, label: <string> }
 	//
 	// Note: we assume that if an element already exists and we try to add it
 	//       again (as may happen if the page changes whilst we're displaying

--- a/src/code/borderDrawer.js
+++ b/src/code/borderDrawer.js
@@ -92,7 +92,7 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 
 	// Did we just make changes to a border? If so, report this, so that the
 	// mutation observer can ignore it.
-	this.didJustMakeChanges = function() {
+	this.hasMadeDOMChanges = function() {
 		const didChanges = justMadeChanges
 		justMadeChanges = false
 		return didChanges

--- a/src/code/borderDrawer.js
+++ b/src/code/borderDrawer.js
@@ -101,7 +101,7 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 	// In case it's detected that an element may've moved due to mutations
 	// FIXME should this handle elements being removed due to mutations?
 	// FIXME what about elements being added (no, that seems beyond scope)?
-	this.updateBorders = function() {
+	this.refreshBorders = function() {
 		resizeHandler()
 	}
 

--- a/src/code/borderManager.js
+++ b/src/code/borderManager.js
@@ -63,7 +63,7 @@ export default function BorderManager(win, doc, contrastChecker) {
 	// object, as returned by the various LandmarksFinder functions.
 	//
 	// { element: HTMLElement, role: <string>, label: <string> }
-	function addBorder(elementInfo) {
+	this.addBorder = function(elementInfo) {
 		if (!borderedElements.has(elementInfo.element)) {  // FIXME pers - togg
 			drawBorderAndLabel(
 				elementInfo.element,
@@ -73,13 +73,12 @@ export default function BorderManager(win, doc, contrastChecker) {
 				borderFontSize)
 		}
 	}
-	this.addBorder = addBorder  // FIXME needed? Could use 'that'?
 
 	// Add the landmark border and label for several elements. Takes an array
 	// of element info objects, as detailed above.
 	this.addBorderToElements = function(elementInfoList) {
 		for (const elementInfo of elementInfoList) {
-			addBorder(elementInfo)
+			this.addBorder(elementInfo)
 		}
 	}
 

--- a/src/code/borderManager.js
+++ b/src/code/borderManager.js
@@ -1,0 +1,218 @@
+import landmarkName from './landmarkName'
+import ContrastChecker from './contrastChecker'
+import { defaultBorderSettings } from './defaults'
+
+// FIXME document and window -> doc and win
+export default function BorderManager() {
+	const contrastChecker = new ContrastChecker()
+	const borderWidthPx = 4
+
+	const borderedElements = new Map()
+	let borderColour = defaultBorderSettings.borderColour      // cached locally
+	let borderFontSize = defaultBorderSettings.borderFontSize  // cached locally
+	let labelFontColour = null  // computed based on border colour
+	let justMadeChanges = false
+
+
+	//
+	// Window resize handling
+	//
+
+	function resizeHandler() {
+		for (const [element, related] of borderedElements) {
+			sizeBorderAndLabel(element, related.border, related.label)
+		}
+	}
+
+	window.addEventListener('resize', resizeHandler)
+
+
+	//
+	// Options handling
+	//
+
+	// Take a local copy of relevant options at the start (this means that
+	// 'gets' of options don't need to be done asynchronously in the rest of
+	// the code).  This also computes the initial label font colour (as it
+	// depends on the border colour, which forms the label's background).
+	browser.storage.sync.get(defaultBorderSettings, function(items) {
+		borderColour = items['borderColour']
+		borderFontSize = items['borderFontSize']
+		updateLabelFontColour()
+	})
+
+	browser.storage.onChanged.addListener(function(changes) {
+		let needUpdate = false
+		if ('borderColour' in changes) {
+			borderColour = changes.borderColour.newValue
+			needUpdate = true
+		}
+		if ('borderFontSize' in changes) {
+			borderFontSize = changes.borderFontSize.newValue
+			needUpdate = true
+		}
+		if (needUpdate) {
+			updateLabelFontColour()
+			redrawBordersAndLabels()
+		}
+	})
+
+
+	//
+	// Public API
+	//
+
+	// Add the landmark border and label for an element Takes an element info
+	// object, as returned by the various LandmarksFinder functions.
+	//
+	// { element: HTMLElement, role: <string>, label: <string> }
+	this.addBorder = function(elementInfo) {
+		if (!borderedElements.has(elementInfo.element)) {  // FIXME pers - togg
+			drawBorderAndLabel(
+				elementInfo.element,
+				landmarkName(elementInfo),
+				borderColour,
+				labelFontColour,  // computed as a result of settings
+				borderFontSize)
+		}
+	}
+
+	// Attempt to remove border from an element.
+	function removeBorderOn(element) {
+		if (borderedElements.has(element)) {
+			deleteBorderAndLabelDivs(element)
+			borderedElements.delete(element)
+		}
+	}
+	this.removeBorderOn = removeBorderOn
+
+	// Did we just make changes to a border? If so, report this, so that the
+	// mutation observer can ignore it.
+	this.didJustMakeChanges = function() {
+		const didChanges = justMadeChanges
+		justMadeChanges = false
+		return didChanges
+	}
+
+	// In case it's detected that an element may've moved due to mutations
+	this.runReszieHandlers = function() {
+		resizeHandler()
+	}
+
+
+	//
+	// Private API
+	//
+
+	// Create an element on the page to act as a border for the element to be
+	// highlighted, and a label for it; position and style them appropriately
+	function drawBorderAndLabel(element, label, colour, fontColour, fontSize) {
+		const zIndex = 10000000
+
+		const labelContent = document.createTextNode(label)
+
+		const borderDiv = document.createElement('div')
+		borderDiv.style.border = borderWidthPx + 'px solid ' + colour
+		borderDiv.style.boxSizing = 'border-box'
+		borderDiv.style.margin = '0'
+		borderDiv.style.padding = '0'
+		// Pass events through - https://stackoverflow.com/a/6441884/1485308
+		borderDiv.style.pointerEvents = 'none'
+		borderDiv.style.position = 'absolute'
+		borderDiv.style.zIndex = zIndex
+
+		const labelDiv = document.createElement('div')
+		labelDiv.style.backgroundColor = colour
+		labelDiv.style.border = 'none'
+		labelDiv.style.boxSizing = 'border-box'
+		labelDiv.style.color = fontColour
+		labelDiv.style.display = 'inline-block'
+		labelDiv.style.fontFamily = 'sans-serif'
+		labelDiv.style.fontSize = fontSize + 'px'
+		labelDiv.style.fontWeight = 'bold'
+		labelDiv.style.margin = '0'
+		labelDiv.style.paddingBottom = '0.25em'
+		labelDiv.style.paddingLeft = '0.75em'
+		labelDiv.style.paddingRight = '0.75em'
+		labelDiv.style.paddingTop = '0.25em'
+		labelDiv.style.position = 'absolute'
+		labelDiv.style.whiteSpace = 'nowrap'
+		labelDiv.style.zIndex = zIndex
+
+		labelDiv.appendChild(labelContent)
+
+		document.body.appendChild(borderDiv)
+		document.body.appendChild(labelDiv)
+		justMadeChanges = true  // seems to be covered by sizeBorderAndLabel()
+		sizeBorderAndLabel(element, borderDiv, labelDiv)
+
+		borderedElements.set(element, { border: borderDiv, label: labelDiv })
+	}
+
+	// Given an element on the page and elements acting as the border and
+	// label, size the border, and position the label, appropriately for the
+	// element
+	function sizeBorderAndLabel(element, border, label) {
+		const elementBounds = element.getBoundingClientRect()
+		const elementTopEdgeStyle = window.scrollY + elementBounds.top + 'px'
+		const elementLeftEdgeStyle = window.scrollX + elementBounds.left + 'px'
+		const elementRightEdgeStyle = document.documentElement.clientWidth -
+			(window.scrollX + elementBounds.right) + 'px'
+
+		border.style.left = elementLeftEdgeStyle
+		border.style.top = elementTopEdgeStyle
+		border.style.width = elementBounds.width + 'px'
+		border.style.height = elementBounds.height + 'px'
+
+		// Try aligning the right edge of the label to the right edge of the
+		// border.
+		//
+		// If the label would go off-screen left, align the left edge of the
+		// label to the left edge of the border.
+
+		label.style.removeProperty('left')  // in case this was set before
+
+		label.style.top = elementTopEdgeStyle
+		label.style.right = elementRightEdgeStyle
+
+		// Is part of the label off-screen?
+		const labelBounds = label.getBoundingClientRect()
+		if (labelBounds.left < 0) {
+			label.style.removeProperty('right')
+			label.style.left = elementLeftEdgeStyle
+		}
+
+		justMadeChanges = true  // seems to be in the right place
+	}
+
+	// Remove known-existing DOM nodes for the border and label
+	// Note: does not remove the record of the element, so as to avoid an
+	//       infinite loop when redrawing borders.
+	function deleteBorderAndLabelDivs(element) {
+		const related = borderedElements.get(element)
+		related.border.remove()
+		related.label.remove()
+		justMadeChanges = true
+	}
+
+	// Work out if the label font colour should be black or white
+	function updateLabelFontColour() {
+		labelFontColour = contrastChecker.foregroundTextColour(
+			borderColour,
+			borderFontSize,
+			true)  // the font is always bold
+	}
+
+	function redrawBordersAndLabels() {
+		for (const [element, related] of borderedElements) {
+			const labelText = related.label.innerText
+			deleteBorderAndLabelDivs(element)
+			drawBorderAndLabel(
+				element,
+				labelText,
+				borderColour,
+				labelFontColour,  // computed as a result of settings
+				borderFontSize)
+		}
+	}
+}

--- a/src/code/borderManager.js
+++ b/src/code/borderManager.js
@@ -30,7 +30,7 @@ export default function BorderManager(win, doc, contrastChecker) {
 
 	// Take a local copy of relevant options at the start (this means that
 	// 'gets' of options don't need to be done asynchronously in the rest of
-	// the code).  This also computes the initial label font colour (as it
+	// the code). This also computes the initial label font colour (as it
 	// depends on the border colour, which forms the label's background).
 	browser.storage.sync.get(defaultBorderSettings, function(items) {
 		borderColour = items['borderColour']
@@ -59,11 +59,11 @@ export default function BorderManager(win, doc, contrastChecker) {
 	// Public API
 	//
 
-	// Add the landmark border and label for an element Takes an element info
+	// Add the landmark border and label for an element. Takes an element info
 	// object, as returned by the various LandmarksFinder functions.
 	//
 	// { element: HTMLElement, role: <string>, label: <string> }
-	this.addBorder = function(elementInfo) {
+	function addBorder(elementInfo) {
 		if (!borderedElements.has(elementInfo.element)) {  // FIXME pers - togg
 			drawBorderAndLabel(
 				elementInfo.element,
@@ -73,15 +73,23 @@ export default function BorderManager(win, doc, contrastChecker) {
 				borderFontSize)
 		}
 	}
+	this.addBorder = addBorder  // FIXME needed? Could use 'that'?
+
+	// Add the landmark border and label for several elements. Takes an array
+	// of element info objects, as detailed above.
+	this.addBorderToElements = function(elementInfoList) {
+		for (const elementInfo of elementInfoList) {
+			addBorder(elementInfo)
+		}
+	}
 
 	// Attempt to remove border from an element.
-	function removeBorderOn(element) {
+	this.removeBorderOn = function(element) {
 		if (borderedElements.has(element)) {
 			deleteBorderAndLabelDivs(element)
 			borderedElements.delete(element)
 		}
 	}
-	this.removeBorderOn = removeBorderOn
 
 	// Did we just make changes to a border? If so, report this, so that the
 	// mutation observer can ignore it.
@@ -92,7 +100,7 @@ export default function BorderManager(win, doc, contrastChecker) {
 	}
 
 	// In case it's detected that an element may've moved due to mutations
-	this.runReszieHandlers = function() {
+	this.runResizeHandlers = function() {
 		resizeHandler()
 	}
 

--- a/src/code/borderManager.js
+++ b/src/code/borderManager.js
@@ -1,10 +1,7 @@
 import landmarkName from './landmarkName'
-import ContrastChecker from './contrastChecker'
 import { defaultBorderSettings } from './defaults'
 
-// FIXME document and window -> doc and win
-export default function BorderManager() {
-	const contrastChecker = new ContrastChecker()
+export default function BorderManager(win, doc, contrastChecker) {
 	const borderWidthPx = 4
 
 	const borderedElements = new Map()
@@ -24,7 +21,7 @@ export default function BorderManager() {
 		}
 	}
 
-	window.addEventListener('resize', resizeHandler)
+	win.addEventListener('resize', resizeHandler)
 
 
 	//
@@ -109,9 +106,9 @@ export default function BorderManager() {
 	function drawBorderAndLabel(element, label, colour, fontColour, fontSize) {
 		const zIndex = 10000000
 
-		const labelContent = document.createTextNode(label)
+		const labelContent = doc.createTextNode(label)
 
-		const borderDiv = document.createElement('div')
+		const borderDiv = doc.createElement('div')
 		borderDiv.style.border = borderWidthPx + 'px solid ' + colour
 		borderDiv.style.boxSizing = 'border-box'
 		borderDiv.style.margin = '0'
@@ -121,7 +118,7 @@ export default function BorderManager() {
 		borderDiv.style.position = 'absolute'
 		borderDiv.style.zIndex = zIndex
 
-		const labelDiv = document.createElement('div')
+		const labelDiv = doc.createElement('div')
 		labelDiv.style.backgroundColor = colour
 		labelDiv.style.border = 'none'
 		labelDiv.style.boxSizing = 'border-box'
@@ -141,8 +138,8 @@ export default function BorderManager() {
 
 		labelDiv.appendChild(labelContent)
 
-		document.body.appendChild(borderDiv)
-		document.body.appendChild(labelDiv)
+		doc.body.appendChild(borderDiv)
+		doc.body.appendChild(labelDiv)
 		justMadeChanges = true  // seems to be covered by sizeBorderAndLabel()
 		sizeBorderAndLabel(element, borderDiv, labelDiv)
 
@@ -154,10 +151,10 @@ export default function BorderManager() {
 	// element
 	function sizeBorderAndLabel(element, border, label) {
 		const elementBounds = element.getBoundingClientRect()
-		const elementTopEdgeStyle = window.scrollY + elementBounds.top + 'px'
-		const elementLeftEdgeStyle = window.scrollX + elementBounds.left + 'px'
-		const elementRightEdgeStyle = document.documentElement.clientWidth -
-			(window.scrollX + elementBounds.right) + 'px'
+		const elementTopEdgeStyle = win.scrollY + elementBounds.top + 'px'
+		const elementLeftEdgeStyle = win.scrollX + elementBounds.left + 'px'
+		const elementRightEdgeStyle = doc.documentElement.clientWidth -
+			(win.scrollX + elementBounds.right) + 'px'
 
 		border.style.left = elementLeftEdgeStyle
 		border.style.top = elementTopEdgeStyle

--- a/src/code/elementFocuser.js
+++ b/src/code/elementFocuser.js
@@ -36,7 +36,7 @@ export default function ElementFocuser(doc, borderDrawer) {
 	// Set focus on the selected landmark element. It takes an element info
 	// object, as returned by the various LandmarksFinder functions.
 	//
-	// { element: HTMLElement, role: <string>, label: <string> }
+	// { element: <HTMLElement>, role: <string>, label: <string> }
 	//
 	// Note: this should only be called if landmarks were found. The check
 	//       for this is done in the main content script, as it involves UI

--- a/src/code/elementFocuser.js
+++ b/src/code/elementFocuser.js
@@ -1,8 +1,6 @@
 import { defaultBorderSettings } from './defaults'
-import BorderManager from './borderManager'
 
-export default function ElementFocuser(doc) {
-	const borderManager = new BorderManager(doc)
+export default function ElementFocuser(doc, borderManager) {
 	const momentaryBorderTime = 2000
 
 	let borderType = defaultBorderSettings.borderType  // cached for simplicity

--- a/src/code/elementFocuser.js
+++ b/src/code/elementFocuser.js
@@ -1,58 +1,29 @@
-import landmarkName from './landmarkName'
 import { defaultBorderSettings } from './defaults'
-import ContrastChecker from './contrastChecker'
+import BorderManager from './borderManager'
 
 export default function ElementFocuser(doc) {
-	const contrastChecker = new ContrastChecker()
-
+	const borderManager = new BorderManager(doc)
 	const momentaryBorderTime = 2000
-	const borderWidthPx = 4
 
-	const settings = {}         // caches options locally (simpler drawing code)
-	let labelFontColour = null  // computed based on border colour
-
-	// Keep a reference to the current element, its role and name for redraws
+	let borderType = defaultBorderSettings.borderType  // cached for simplicity
 	let currentlyFocusedElementInfo = null
-
-	// Drawn border elements: the first is used as a convenient indicator that
-	// the border is drawn. They are both needed when resizing/repositioning
-	// the border/label.
-	let currentBorderElement = null
-	let currentLabelElement = null
-
-	let currentResizeHandler = null  // tracked so it can be removed
-	let borderRemovalTimer = null    // tracked so it can be cleared
-	let justMadeChanges = false      // we are asked this by mutation observer
+	let borderRemovalTimer = null
 
 
 	//
-	// Options-handling
+	// Options handling
 	//
 
-	// Take a local copy of all options at the start (this means that 'gets' of
-	// options don't need to be done asynchronously in the rest of the code).
-	// This also computes the initial label font colour (as it depends on the
-	// border colour, which forms the label's background).
+	// Take a local copy of the border type option at the start (this means
+	// that 'gets' of options don't need to be done asynchronously in the rest
+	// of the code).
 	browser.storage.sync.get(defaultBorderSettings, function(items) {
-		for (const option in items) {
-			settings[option] = items[option]
-		}
-		updateLabelFontColour()
+		borderType = items['borderType']
 	})
 
 	browser.storage.onChanged.addListener(function(changes) {
-		for (const option in changes) {
-			if (settings.hasOwnProperty(option)) {
-				settings[option] = changes[option].newValue
-			}
-		}
-
-		if ('borderColour' in changes || 'borderFontSize' in changes) {
-			updateLabelFontColour()
-			redrawBorderAndLabel()
-		}
-
 		if ('borderType' in changes) {
+			borderType = changes.borderType.newValue
 			borderTypeChange()
 		}
 	})
@@ -84,10 +55,10 @@ export default function ElementFocuser(doc) {
 
 		// Add the border and set a borderRemovalTimer to remove it (if
 		// required by user settings)
-		if (settings.borderType !== 'none') {
-			addBorder(elementInfo)
+		if (borderType !== 'none') {
+			borderManager.addBorder(elementInfo)
 
-			if (settings.borderType === 'momentary') {
+			if (borderType === 'momentary') {
 				if (borderRemovalTimer) {
 					clearTimeout(borderRemovalTimer)
 				}
@@ -109,17 +80,9 @@ export default function ElementFocuser(doc) {
 	}
 
 	function removeBorderOnCurrentlySelectedElement() {
-		if (currentBorderElement) {
-			justMadeChanges = true
-			currentBorderElement.remove()
-			currentLabelElement.remove()
-			window.removeEventListener('resize', currentResizeHandler)
-			currentBorderElement = null
-			currentLabelElement = null
+		if (currentlyFocusedElementInfo) {
+			borderManager.removeBorderOn(currentlyFocusedElementInfo.element)
 		}
-
-		// currentlyFocusedElementInfo is not deleted, as we may be in the
-		// middle of updating (redrawing) a border due to settings changes
 	}
 
 	// This needs to be a separate (and public) declaration because external
@@ -127,12 +90,11 @@ export default function ElementFocuser(doc) {
 	this.removeBorderOnCurrentlySelectedElement
 		= removeBorderOnCurrentlySelectedElement
 
+	// FIXME (re)move
 	// Did we just make changes to a border? If so, report this, so that the
 	// mutation observer can ignore it.
 	this.didJustMakeChanges = function() {
-		const didChanges = justMadeChanges
-		justMadeChanges = false
-		return didChanges
+		return borderManager.didJustMakeChanges()
 	}
 
 	// When the document is changed, the currently-focused element may have
@@ -140,11 +102,17 @@ export default function ElementFocuser(doc) {
 	this.checkFocusedElement = function() {
 		if (currentlyFocusedElementInfo) {
 			if (!doc.body.contains(currentlyFocusedElementInfo.element)) {
-				currentlyFocusedElementInfo = null  // can't resize anymore
 				removeBorderOnCurrentlySelectedElement()
+				currentlyFocusedElementInfo = null  // can't resize anymore
 			} else {
-				currentResizeHandler()
+				borderManager.runReszieHandlers()
 			}
+		}
+	}
+
+	this.addBorderToElements = function(elementInfoList) {
+		for (const elementInfo of elementInfoList) {
+			borderManager.addBorder(elementInfo)
 		}
 	}
 
@@ -153,134 +121,11 @@ export default function ElementFocuser(doc) {
 	// Private API
 	//
 
-	// Add the landmark border and label for an element
-	// Note: only one should be drawn at a time
-	function addBorder(elementInfo) {
-		drawBorderAndLabel(
-			elementInfo.element,
-			landmarkName(elementInfo),
-			settings.borderColour,
-			labelFontColour,  // computed as a result of settings
-			settings.borderFontSize)
-	}
-
-	// Create an element on the page to act as a border for the element to be
-	// highlighted, and a label for it; position and style them appropriately
-	function drawBorderAndLabel(element, label, colour, fontColour, fontSize) {
-		const zIndex = 10000000
-
-		const labelContent = document.createTextNode(label)
-
-		const borderDiv = document.createElement('div')
-		borderDiv.style.border = borderWidthPx + 'px solid ' + colour
-		borderDiv.style.boxSizing = 'border-box'
-		borderDiv.style.margin = '0'
-		borderDiv.style.padding = '0'
-		// Pass events through - https://stackoverflow.com/a/6441884/1485308
-		borderDiv.style.pointerEvents = 'none'
-		borderDiv.style.position = 'absolute'
-		borderDiv.style.zIndex = zIndex
-
-		const labelDiv = document.createElement('div')
-		labelDiv.style.backgroundColor = colour
-		labelDiv.style.border = 'none'
-		labelDiv.style.boxSizing = 'border-box'
-		labelDiv.style.color = fontColour
-		labelDiv.style.display = 'inline-block'
-		labelDiv.style.fontFamily = 'sans-serif'
-		labelDiv.style.fontSize = fontSize + 'px'
-		labelDiv.style.fontWeight = 'bold'
-		labelDiv.style.margin = '0'
-		labelDiv.style.paddingBottom = '0.25em'
-		labelDiv.style.paddingLeft = '0.75em'
-		labelDiv.style.paddingRight = '0.75em'
-		labelDiv.style.paddingTop = '0.25em'
-		labelDiv.style.position = 'absolute'
-		labelDiv.style.whiteSpace = 'nowrap'
-		labelDiv.style.zIndex = zIndex
-
-		labelDiv.appendChild(labelContent)
-
-		document.body.appendChild(borderDiv)
-		document.body.appendChild(labelDiv)
-		justMadeChanges = true  // seems to be covered by sizeBorderAndLabel()
-
-		sizeBorderAndLabel(element, borderDiv, labelDiv)
-
-		currentBorderElement = borderDiv
-		currentLabelElement = labelDiv
-		currentResizeHandler = () => resize(element)
-
-		window.addEventListener('resize', currentResizeHandler)
-	}
-
-	// Given an element on the page and elements acting as the border and
-	// label, size the border, and position the label, appropriately for the
-	// element
-	function sizeBorderAndLabel(element, border, label) {
-		const elementBounds = element.getBoundingClientRect()
-		const elementTopEdgeStyle = window.scrollY + elementBounds.top + 'px'
-		const elementLeftEdgeStyle = window.scrollX + elementBounds.left + 'px'
-		const elementRightEdgeStyle = document.documentElement.clientWidth -
-			(window.scrollX + elementBounds.right) + 'px'
-
-		border.style.left = elementLeftEdgeStyle
-		border.style.top = elementTopEdgeStyle
-		border.style.width = elementBounds.width + 'px'
-		border.style.height = elementBounds.height + 'px'
-
-		// Try aligning the right edge of the label to the right edge of the
-		// border.
-		//
-		// If the label would go off-screen left, align the left edge of the
-		// label to the left edge of the border.
-
-		label.style.removeProperty('left')  // in case this was set before
-
-		label.style.top = elementTopEdgeStyle
-		label.style.right = elementRightEdgeStyle
-
-		// Is part of the label off-screen?
-		const labelBounds = label.getBoundingClientRect()
-		if (labelBounds.left < 0) {
-			label.style.removeProperty('right')
-			label.style.left = elementLeftEdgeStyle
-		}
-
-		justMadeChanges = true  // seems to be in the right place
-	}
-
-	// When the viewport changes, update the border <div>'s size
-	function resize(element) {
-		sizeBorderAndLabel(
-			element,
-			currentBorderElement,
-			currentLabelElement)
-	}
-
-	// Work out if the label font colour should be black or white
-	function updateLabelFontColour() {
-		labelFontColour = contrastChecker.foregroundTextColour(
-			settings.borderColour,
-			settings.borderFontSize,
-			true)  // the font is always bold
-	}
-
-	// Redraw an existing border
-	function redrawBorderAndLabel() {
-		if (currentBorderElement) {
-			if (settings.borderType === 'persistent') {
-				removeBorderOnCurrentlySelectedElement()
-				addBorder(currentlyFocusedElementInfo)
-			}
-		}
-	}
-
 	// Should a border be added/removed?
 	function borderTypeChange() {
-		if (settings.borderType === 'persistent') {
+		if (borderType === 'persistent') {
 			if (currentlyFocusedElementInfo) {
-				addBorder(currentlyFocusedElementInfo)
+				borderManager.addBorder(currentlyFocusedElementInfo)
 			}
 		} else {
 			removeBorderOnCurrentlySelectedElement()

--- a/src/code/elementFocuser.js
+++ b/src/code/elementFocuser.js
@@ -40,7 +40,7 @@ export default function ElementFocuser(doc, borderManager) {
 	//       for this is done in the main content script, as it involves UI
 	//       activity, and couples finding and focusing.
 	this.focusElement = function(elementInfo) {
-		removeBorderOnCurrentlySelectedElement()
+		this.removeBorderOnCurrentlySelectedElement()
 
 		// Ensure that the element is focusable
 		const originalTabindex = elementInfo.element.getAttribute('tabindex')
@@ -62,7 +62,7 @@ export default function ElementFocuser(doc, borderManager) {
 				}
 
 				borderRemovalTimer = setTimeout(
-					removeBorderOnCurrentlySelectedElement,
+					this.removeBorderOnCurrentlySelectedElement,
 					momentaryBorderTime)
 			}
 		}
@@ -77,24 +77,18 @@ export default function ElementFocuser(doc, borderManager) {
 		currentlyFocusedElementInfo = elementInfo
 	}
 
-	function removeBorderOnCurrentlySelectedElement() {
+	this.removeBorderOnCurrentlySelectedElement = function() {
 		if (currentlyFocusedElementInfo) {
 			borderManager.removeBorderOn(currentlyFocusedElementInfo.element)
 		}
 	}
-
-	// This needs to be a separate (and public) declaration because external
-	// stuff calls it, but the options-handling code can't access 'this'.
-	// FIXME: is that correct? Could use 'that'?
-	this.removeBorderOnCurrentlySelectedElement
-		= removeBorderOnCurrentlySelectedElement
 
 	// When the document is changed, the currently-focused element may have
 	// been removed, or at least changed size/position
 	this.checkFocusedElement = function() {
 		if (currentlyFocusedElementInfo) {
 			if (!doc.body.contains(currentlyFocusedElementInfo.element)) {
-				removeBorderOnCurrentlySelectedElement()
+				this.removeBorderOnCurrentlySelectedElement()
 				currentlyFocusedElementInfo = null  // can't resize anymore
 			} else {
 				borderManager.runResizeHandlers()
@@ -114,7 +108,7 @@ export default function ElementFocuser(doc, borderManager) {
 				borderManager.addBorder(currentlyFocusedElementInfo)
 			}
 		} else {
-			removeBorderOnCurrentlySelectedElement()
+			this.removeBorderOnCurrentlySelectedElement()
 		}
 	}
 }

--- a/src/code/elementFocuser.js
+++ b/src/code/elementFocuser.js
@@ -1,6 +1,6 @@
 import { defaultBorderSettings } from './defaults'
 
-export default function ElementFocuser(doc, borderManager) {
+export default function ElementFocuser(doc, borderDrawer) {
 	const momentaryBorderTime = 2000
 
 	let borderType = defaultBorderSettings.borderType  // cached for simplicity
@@ -54,7 +54,7 @@ export default function ElementFocuser(doc, borderManager) {
 		// Add the border and set a borderRemovalTimer to remove it (if
 		// required by user settings)
 		if (borderType !== 'none') {
-			borderManager.addBorder(elementInfo)
+			borderDrawer.addBorder(elementInfo)
 
 			if (borderType === 'momentary') {
 				if (borderRemovalTimer) {
@@ -79,7 +79,7 @@ export default function ElementFocuser(doc, borderManager) {
 
 	this.removeBorderOnCurrentlySelectedElement = function() {
 		if (currentlyFocusedElementInfo) {
-			borderManager.removeBorderOn(currentlyFocusedElementInfo.element)
+			borderDrawer.removeBorderOn(currentlyFocusedElementInfo.element)
 		}
 	}
 
@@ -91,7 +91,7 @@ export default function ElementFocuser(doc, borderManager) {
 				this.removeBorderOnCurrentlySelectedElement()
 				currentlyFocusedElementInfo = null  // can't resize anymore
 			} else {
-				borderManager.runResizeHandlers()
+				borderDrawer.runResizeHandlers()
 			}
 		}
 	}
@@ -105,7 +105,7 @@ export default function ElementFocuser(doc, borderManager) {
 	function borderTypeChange() {
 		if (borderType === 'persistent') {
 			if (currentlyFocusedElementInfo) {
-				borderManager.addBorder(currentlyFocusedElementInfo)
+				borderDrawer.addBorder(currentlyFocusedElementInfo)
 			}
 		} else {
 			this.removeBorderOnCurrentlySelectedElement()

--- a/src/code/elementFocuser.js
+++ b/src/code/elementFocuser.js
@@ -1,6 +1,7 @@
 import { defaultBorderSettings } from './defaults'
 
 export default function ElementFocuser(doc, borderDrawer) {
+	const that = this  // for preference-handling code
 	const momentaryBorderTime = 2000
 
 	let borderType = defaultBorderSettings.borderType  // cached for simplicity
@@ -115,7 +116,7 @@ export default function ElementFocuser(doc, borderDrawer) {
 				borderDrawer.addBorder(currentlyFocusedElementInfo)
 			}
 		} else {
-			this.removeBorderOnCurrentlySelectedElement()
+			that.removeBorderOnCurrentlySelectedElement()
 		}
 	}
 }

--- a/src/code/elementFocuser.js
+++ b/src/code/elementFocuser.js
@@ -39,8 +39,8 @@ export default function ElementFocuser(doc, borderDrawer) {
 	// Note: this should only be called if landmarks were found. The check
 	//       for this is done in the main content script, as it involves UI
 	//       activity, and couples finding and focusing.
-	this.focusElement = function(elementInfo) {
-		this.removeBorderOnCurrentlySelectedElement()
+	this.focusElement = function(elementInfo, drawBorder = true) {
+		if (drawBorder) this.removeBorderOnCurrentlySelectedElement()
 
 		// Ensure that the element is focusable
 		const originalTabindex = elementInfo.element.getAttribute('tabindex')
@@ -53,13 +53,11 @@ export default function ElementFocuser(doc, borderDrawer) {
 
 		// Add the border and set a borderRemovalTimer to remove it (if
 		// required by user settings)
-		if (borderType !== 'none') {
+		if (drawBorder && borderType !== 'none') {
 			borderDrawer.addBorder(elementInfo)
 
 			if (borderType === 'momentary') {
-				if (borderRemovalTimer) {
-					clearTimeout(borderRemovalTimer)
-				}
+				this.clearRemovalTimer()
 
 				borderRemovalTimer = setTimeout(
 					this.removeBorderOnCurrentlySelectedElement,  // TODO dblchk
@@ -94,6 +92,14 @@ export default function ElementFocuser(doc, borderDrawer) {
 				this.removeBorderOnCurrentlySelectedElement()  // TODO dblchk
 				currentlyFocusedElementInfo = null  // can't resize anymore
 			}
+		}
+	}
+
+	// If the border is scheduled to be removed, and the user toggles all
+	// borders on, then the border should not be removed anymore.
+	this.clearRemovalTimer = function() {
+		if (borderRemovalTimer) {
+			clearTimeout(borderRemovalTimer)
 		}
 	}
 

--- a/src/code/elementFocuser.js
+++ b/src/code/elementFocuser.js
@@ -88,7 +88,7 @@ export default function ElementFocuser(doc, borderDrawer) {
 	// Note: this doesn't call the border drawer to refresh all borders, as
 	//       this object is mainly concerned with just the current one, but
 	//       after a mutation, any borders that are drawn should be refreshed.
-	this.updateFocusedElement = function() {
+	this.refreshFocusedElement = function() {
 		if (currentlyFocusedElementInfo) {
 			if (!doc.body.contains(currentlyFocusedElementInfo.element)) {
 				this.removeBorderOnCurrentlySelectedElement()  // TODO dblchk

--- a/src/code/elementFocuser.js
+++ b/src/code/elementFocuser.js
@@ -85,15 +85,9 @@ export default function ElementFocuser(doc, borderManager) {
 
 	// This needs to be a separate (and public) declaration because external
 	// stuff calls it, but the options-handling code can't access 'this'.
+	// FIXME: is that correct? Could use 'that'?
 	this.removeBorderOnCurrentlySelectedElement
 		= removeBorderOnCurrentlySelectedElement
-
-	// FIXME (re)move
-	// Did we just make changes to a border? If so, report this, so that the
-	// mutation observer can ignore it.
-	this.didJustMakeChanges = function() {
-		return borderManager.didJustMakeChanges()
-	}
 
 	// When the document is changed, the currently-focused element may have
 	// been removed, or at least changed size/position
@@ -103,14 +97,8 @@ export default function ElementFocuser(doc, borderManager) {
 				removeBorderOnCurrentlySelectedElement()
 				currentlyFocusedElementInfo = null  // can't resize anymore
 			} else {
-				borderManager.runReszieHandlers()
+				borderManager.runResizeHandlers()
 			}
-		}
-	}
-
-	this.addBorderToElements = function(elementInfoList) {
-		for (const elementInfo of elementInfoList) {
-			borderManager.addBorder(elementInfo)
 		}
 	}
 

--- a/src/code/elementFocuser.js
+++ b/src/code/elementFocuser.js
@@ -62,7 +62,7 @@ export default function ElementFocuser(doc, borderDrawer) {
 				}
 
 				borderRemovalTimer = setTimeout(
-					this.removeBorderOnCurrentlySelectedElement,
+					this.removeBorderOnCurrentlySelectedElement,  // TODO dblchk
 					momentaryBorderTime)
 			}
 		}
@@ -84,14 +84,15 @@ export default function ElementFocuser(doc, borderDrawer) {
 	}
 
 	// When the document is changed, the currently-focused element may have
-	// been removed, or at least changed size/position
-	this.checkFocusedElement = function() {
+	// been removed, or at least changed size/position.
+	// Note: this doesn't call the border drawer to refresh all borders, as
+	//       this object is mainly concerned with just the current one, but
+	//       after a mutation, any borders that are drawn should be refreshed.
+	this.updateFocusedElement = function() {
 		if (currentlyFocusedElementInfo) {
 			if (!doc.body.contains(currentlyFocusedElementInfo.element)) {
-				this.removeBorderOnCurrentlySelectedElement()
+				this.removeBorderOnCurrentlySelectedElement()  // TODO dblchk
 				currentlyFocusedElementInfo = null  // can't resize anymore
-			} else {
-				borderDrawer.runResizeHandlers()
 			}
 		}
 	}

--- a/src/code/landmarksFinder.js
+++ b/src/code/landmarksFinder.js
@@ -311,7 +311,11 @@ export default function LandmarksFinder(win, doc) {
 		getLandmarks(doc.body.parentNode, 0, null)  // supports role on <body>
 	}
 
-	this.filter = function() {
+	this.getNumberOfLandmarks = function() {
+		return landmarks.length
+	}
+
+	this.allDepthsRolesLabelsSelectors = function() {
 		return landmarks.map(landmark => ({
 			depth: landmark.depth,
 			role: landmark.role,
@@ -320,8 +324,12 @@ export default function LandmarksFinder(win, doc) {
 		}))
 	}
 
-	this.getNumberOfLandmarks = function() {
-		return landmarks.length
+	this.allElementsRolesLabels = function() {
+		return landmarks.map(landmark => ({
+			element: landmark.element,
+			role: landmark.role,
+			label: landmark.label
+		}))
 	}
 
 	// These all return elements and their public-facing info:
@@ -345,15 +353,5 @@ export default function LandmarksFinder(win, doc) {
 	this.getMainElementRoleLabel = function() {
 		return mainElementIndex < 0 ?
 			null : updateSelectedIndexAndReturnElementInfo(mainElementIndex)
-	}
-
-	// This returns a list of elements and their public-facing info:
-
-	this.allElementsRolesLabels = function() {
-		return landmarks.map(landmark => ({
-			element: landmark.element,
-			role: landmark.role,
-			label: landmark.label
-		}))
 	}
 }

--- a/src/code/landmarksFinder.js
+++ b/src/code/landmarksFinder.js
@@ -346,4 +346,14 @@ export default function LandmarksFinder(win, doc) {
 		return mainElementIndex < 0 ?
 			null : updateSelectedIndexAndReturnElementInfo(mainElementIndex)
 	}
+
+	// This returns a list of elements and their public-facing info:
+
+	this.allElementsRolesLabels = function() {
+		return landmarks.map(landmark => ({
+			element: landmark.element,
+			role: landmark.role,
+			label: landmark.label
+		}))
+	}
 }

--- a/src/code/logger.js
+++ b/src/code/logger.js
@@ -1,6 +1,6 @@
 import { defaultDebugSettings } from './defaults'
 
-export default function Logger() {
+export default function Logger(win) {
 	const that = this
 	const messagesReceivedDuringInit = []  // whilst retrieving user preference
 
@@ -21,8 +21,8 @@ export default function Logger() {
 			// Ensure the correct line number is reported
 			// https://stackoverflow.com/a/32928812/1485308
 			// https://stackoverflow.com/a/28668819/1485308
-			that.log = console.log.bind(window.console)
-			that.timeStamp = console.timeStamp.bind(window.console)
+			that.log = console.log.bind(win.console)
+			that.timeStamp = console.timeStamp.bind(win.console)
 		} else {
 			if (messagesReceivedDuringInit.length > 0) {
 				messagesReceivedDuringInit.length = 0

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -3,6 +3,7 @@
 	--hlb: #159957;
 	--words: #606c71;
 	--warn: #d00;
+	--lightWarn: #fee;
 }
 
 body {
@@ -46,21 +47,17 @@ details:not(:first-child) {
 
 summary > :first-child { display: inline; }
 
+.error, [data-warning] > a {
+	color: var(--warn);
+}
+
 [data-warning] {
 	display: none;  /* overidden by script if need be */
 	border: 1px solid var(--warn);
-	background-color: #fee;
+	background-color: var(--lightWarn);
 	color: var(--warn);
 	padding: 1em;
 	border-radius: 1em;
-}
-
-[data-warning] > a {
-	color: var(--warn);
-}
-
-summary.error {
-	color: var(--warn);
 }
 
 table {
@@ -84,9 +81,8 @@ th, td {
 td:last-child { text-align: center; }
 
 td.error {
-	background-color: var(--warn);
-	color: white;
-	font-weight: bold;
+	background-color: var(--lightWarn);
+	border: 1px solid var(--warn);
 }
 
 a.config {

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -4,6 +4,7 @@
 	--words: #606c71;
 	--warn: #d00;
 	--lightWarn: #fee;
+	--lightNeutral: #efefef;
 }
 
 body {
@@ -47,17 +48,38 @@ details:not(:first-child) {
 
 summary > :first-child { display: inline; }
 
-.error, [data-warning] > a {
+svg {
+	height: 0.75em;
+	width: auto;
+}
+
+path { fill: var(--warn); }
+
+#symbol { display: none; }
+
+.configAction, .errorAction, [data-warning] {
+	border-radius: 1em;
+	padding: 1em;
+	display: inline-block;
+}
+
+.configAction {
+	border: 1px solid var(--words);
+	color: var(--words);
+	background-color: var(--lightNeutral);
+}
+
+.errorAction, [data-warning] {
+	border: 1px solid var(--warn);
+	background-color: var(--lightWarn);
+}
+
+[data-warning], [data-warning] > a, .errorAction, .errorItem {
 	color: var(--warn);
 }
 
 [data-warning] {
 	display: none;  /* overidden by script if need be */
-	border: 1px solid var(--warn);
-	background-color: var(--lightWarn);
-	color: var(--warn);
-	padding: 1em;
-	border-radius: 1em;
 }
 
 table {
@@ -65,7 +87,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr:nth-child(odd) { background-color: #efefef; }
+tr:nth-child(odd) { background-color: var(--lightNeutral); }
 
 tr:first-child {
 	background-color: var(--hla);
@@ -79,19 +101,6 @@ th, td {
 }
 
 td:last-child { text-align: center; }
-
-td.error {
-	background-color: var(--lightWarn);
-	border: 1px solid var(--warn);
-}
-
-a.config {
-	display: inline-block;
-	border-radius: 1em;
-	border: 1px solid var(--words);
-	padding: 1em;
-	color: var(--words);
-}
 
 footer { padding: 2em; }
 

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -56,9 +56,8 @@ tr:first-child {
 	color: white;
 }
 
-th, td { padding: 0.5em; }
-
-th {
+th, td {
+	padding: 0.5em;
 	padding-left: 2em;
 	padding-right: 2em;
 }

--- a/src/static/help.css
+++ b/src/static/help.css
@@ -2,6 +2,7 @@
 	--hla: #155799;
 	--hlb: #159957;
 	--words: #606c71;
+	--warn: #d00;
 }
 
 body {
@@ -35,6 +36,7 @@ details {
 
 details.call-to-action {
 	border: none;
+	border-radius: 1em;
 	background-color: #eee;
 }
 
@@ -43,6 +45,23 @@ details:not(:first-child) {
 }
 
 summary > :first-child { display: inline; }
+
+[data-warning] {
+	display: none;  /* overidden by script if need be */
+	border: 1px solid var(--warn);
+	background-color: #fee;
+	color: var(--warn);
+	padding: 1em;
+	border-radius: 1em;
+}
+
+[data-warning] > a {
+	color: var(--warn);
+}
+
+summary.error {
+	color: var(--warn);
+}
 
 table {
 	margin-top: 0.5em;
@@ -65,7 +84,7 @@ th, td {
 td:last-child { text-align: center; }
 
 td.error {
-	background-color: #d00;
+	background-color: var(--warn);
 	color: white;
 	font-weight: bold;
 }

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -15,6 +15,7 @@
 		<details class="call-to-action" id="actions-install" open>
 			<summary><h2>Thanks for installing Landmarks</h2></summary>
 			<p>You may want to learn how to <a href="#section-keyboard-navigation">navigate via keyboard</a> and set up keyboard shortcuts.</p>
+			<p data-warning>Your browser allows extensions to pre-set up to four keyboard shortcuts, but Landmarks provides more than this. <a href="#section-keyboard-navigation">At least one available keyboard shortcut is not set; you may wish to review them.</a></p>
 		</details>
 		<details class="call-to-action" id="actions-update" open>
 			<summary><h2>Landmarks was updated</h2></summary>
@@ -26,6 +27,7 @@
 					<p>Learn how to <a href="#section-keyboard-navigation">navigate via keyboard</a> and set up keyboard shortcuts.</p>
 				</li>
 			</ul>
+			<p data-warning><a href="#section-keyboard-navigation">At least one available keyboard shortcut is not set; you may wish to review them.</a></p>
 		</details>
 		<details id="section-new">
 			<summary><h2>What's new?</h2></summary>

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -15,6 +15,7 @@
 		<details class="call-to-action" id="actions-install" open>
 			<summary><h2>Thanks for installing Landmarks</h2></summary>
 			<p>You may want to learn how to <a href="#section-keyboard-navigation">navigate via keyboard</a> and set up keyboard shortcuts.</p>
+			<!-- Note the following paragraph is repeated below. -->
 			<p data-warning>Your browser allows extensions to pre-set up to four keyboard shortcuts, but Landmarks provides more than this. <a href="#section-keyboard-navigation">At least one available keyboard shortcut is not set; you may wish to review them.</a></p>
 		</details>
 		<details class="call-to-action" id="actions-update" open>
@@ -27,7 +28,8 @@
 					<p>Learn how to <a href="#section-keyboard-navigation">navigate via keyboard</a> and set up keyboard shortcuts.</p>
 				</li>
 			</ul>
-			<p data-warning><a href="#section-keyboard-navigation">At least one available keyboard shortcut is not set; you may wish to review them.</a></p>
+			<!-- Note the following paragraph is repeated above. -->
+			<p data-warning>Your browser allows extensions to pre-set up to four keyboard shortcuts, but Landmarks provides more than this. <a href="#section-keyboard-navigation">At least one available keyboard shortcut is not set; you may wish to review them.</a></p>
 		</details>
 		<details id="section-new">
 			<summary><h2>What's new?</h2></summary>
@@ -43,7 +45,8 @@
 			<p>For more details, consult the <a href="https://github.com/matatk/landmarks/blob/master/CHANGELOG.md#landmarks-changelog">change log</a>.</p>
 		</details>
 		<details id="section-keyboard-navigation" open>
-			<summary><h2>Keyboard navigation</h2></summary>
+			<!-- Thanks to Heydon Pickering for the SVG: https://twitter.com/heydonworks/status/928999112296620032 :-) -->
+			<summary><h2>Keyboard navigation<span id="symbol"> <svg viewBox="1 1 8 8"><path d="m5 1-4 8h8zm-.36 2.6h.7v3h-.7v-2.8594zm.36 3.4c.4 0 .5.3.5.6-.1.3-.4.45-.63.4-.27-.1-.47-.4-.37-.63.07-.17.20-.37.50-.37z"/></svg></h2></summary>
 			<p>You can use shortcut keys to navigate between landmarks, as detailed below. When you do, landmarks will be focused, and a border shown according to your <a href="#section-border-preferences">border preferences</a>.</p>
 			<div id="keyboard-shortcuts-table"></div>
 			<p data-link="shortcuts"></p>
@@ -72,7 +75,7 @@
 				</li>
 			</ol>
 		</details>
-		<details id="section-sidebar">
+		<details id="section-sidebar" open>
 			<summary><h2>Sidebar</h2></summary>
 			<p>On Firefox and Opera, you can also explore landmarks on the page by way of a sidebar. You can choose in the preferences whether you'd like to use both the toolbar pop-up and sidebar, or just the sidebar.</p>
 			<p data-link="settings"></p>

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -51,7 +51,7 @@
 				<label for="debug-info" data-message="prefsDebugInfo"></label>
 			</div>
 			<div class="input-first">
-				<button id="reset-all" data-message="prefsResetAll" class="browser-style"></button>
+				<button id="reset-to-defaults" data-message="prefsResetAll" class="browser-style"></button>
 			</div>
 		</details>
 

--- a/test/test-landmarks.js
+++ b/test/test-landmarks.js
@@ -30,7 +30,10 @@ function createTest(testName, testFixture, testData) {
 		const LandmarksFinder = require(testCodePath)
 		const lf = new LandmarksFinder(doc.defaultView, doc)
 		lf.find()
-		assert.deepEqual(lf.filter(), data.expected, testName)
+		assert.deepEqual(
+			lf.allDepthsRolesLabelsSelectors(),
+			data.expected,
+			testName)
 	}
 }
 


### PR DESCRIPTION
Naughty! This really should’ve been split up into smaller PRs, though I think I am starting to get into this new commit style :-). Anyway, this does a couple of things:

* Adds help page support for indicating to the user when a keyboard shortcut is not set (in support of #165).
* Implements a keyboard shortcut that toggles the display of all landmarks (in support of #120).

In support of this, it required splitting the ElementFocuser into an ElementFocuser and a BorderDrawer. A lot of API naming cleanup and code tidying was done too.

A further PR will add UI to the pop-up that mouse users can use to access this feature.