### PR TITLE
fix(UI): Add help and preferences links to GUIs

### DIFF
--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -4,14 +4,24 @@
 		<meta charset="UTF-8">
 		<title></title>
 		<link rel="stylesheet" href="gui.css">
+		<!-- ui -->
+		<link rel="stylesheet" href="sidebar.css">
+		<!-- /ui -->
 	</head>
 	<body>
-		<h1 id="heading"></h1>
-		<div id="landmarks"></div>
-		<label id="show-all-label">
-			<input type="checkbox" id="show-all">
-		</label>
-
+		<div id="container">
+			<h1 id="heading"></h1>
+			<div id="landmarks"></div>
+			<div id="show-all">
+				<label id="show-all-label">
+					<input type="checkbox" id="show-all">
+				</label>
+			</div>
+		</div>
+		<div id="bottom">
+			<button>Help</button>
+			<button>Options</button>
+		</div>
 		<script src="GUIJS"></script>
 	</body>
 </html>

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -12,11 +12,9 @@
 		<div id="container">
 			<h1 id="heading"></h1>
 			<div id="landmarks"></div>
-			<div id="show-all-container">
-				<label id="show-all-label">
-					<input type="checkbox" id="show-all">
-				</label>
-			</div>
+			<label id="show-all-label">
+				<input type="checkbox" id="show-all">
+			</label>
 		</div>
 		<div id="bottom">
 			<button>Help</button>

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -12,7 +12,7 @@
 		<div id="container">
 			<h1 id="heading"></h1>
 			<div id="landmarks"></div>
-			<div id="show-all">
+			<div id="show-all-container">
 				<label id="show-all-label">
 					<input type="checkbox" id="show-all">
 				</label>

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -10,15 +10,15 @@
 	</head>
 	<body>
 		<div id="container">
-			<h1 id="heading"></h1>
+			<h1 data-message="popupHeading"></h1>
 			<div id="landmarks"></div>
-			<label id="show-all-label">
+			<label id="show-all-label" data-message="popupShowAllLandmarks">
 				<input type="checkbox" id="show-all">
 			</label>
 		</div>
 		<div id="bottom">
-			<button id="help">Help</button>
-			<button id="settings">Preferences</button>
+			<button id="help" data-message="popupHelpButton"></button>
+			<button id="settings" data-message="popupPreferencesButton"></button>
 		</div>
 		<script src="GUIJS"></script>
 	</body>

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -9,16 +9,16 @@
 		<!-- /ui -->
 	</head>
 	<body>
-		<div id="container">
+		<div id="content">
 			<h1 data-message="popupHeading"></h1>
 			<div id="landmarks"></div>
 			<label id="show-all-label" data-message="popupShowAllLandmarks">
 				<input type="checkbox" id="show-all">
 			</label>
 		</div>
-		<div id="bottom">
-			<button id="help" data-message="popupHelpButton"></button>
-			<button id="settings" data-message="popupPreferencesButton"></button>
+		<div id="links">
+			<a tabindex="0" id="help" data-message="popupHelpButton"></a>
+			<a tabindex="0" id="settings" data-message="popupPreferencesButton"></a>
 		</div>
 		<script src="GUIJS"></script>
 	</body>

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -17,8 +17,8 @@
 			</label>
 		</div>
 		<div id="bottom">
-			<button>Help</button>
-			<button>Options</button>
+			<button id="help">Help</button>
+			<button id="settings">Preferences</button>
 		</div>
 		<script src="GUIJS"></script>
 	</body>

--- a/src/assemble/messages.common.json
+++ b/src/assemble/messages.common.json
@@ -53,18 +53,19 @@
     "message": "No main landmark found."
   },
 
+  "popupHelpButton": {
+    "message": "Help"
+  },
 
-
-
-  "inspectButtonName": {
-    "message": "Inspect"
+  "popupPreferencesButton": {
+    "message": "Preferences"
   },
 
 
 
 
   "prefsTitle": {
-    "message": "Landmarks Options"
+    "message": "Landmarks preferences"
   },
 
   "prefsBorderType": {
@@ -216,6 +217,10 @@
 
 
 
+
+  "inspectButtonName": {
+    "message": "Inspect"
+  },
 
   "devToolsConnectionError": {
     "message": "This DevTools frame has become disconnected, probably due to reloading the extension. You'll need to reload this frame for it to recieve landmark updates again."

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -100,6 +100,7 @@ function contentListener(message, sendingPort) {
 }
 
 // TODO DRY with devToolsListener
+// TODO DRY with splashListener
 function popupAndSidebarListener(message) {  // also gets: sendingPort
 	switch (message.name) {
 		case 'get-landmarks':
@@ -111,12 +112,21 @@ function popupAndSidebarListener(message) {  // also gets: sendingPort
 		case 'toggle-all-landmarks':
 			sendToActiveContentScriptIfExists(message)
 			break
+		case 'open-help':
+			browser.tabs.update({
+				url: browser.runtime.getURL('help.html')
+			})
+			break
+		case 'open-settings':
+			browser.runtime.openOptionsPage()
+			break
 		default:
 			throw Error(`Unknown message ${JSON.stringify(message)} from popup or sidebar`)
 	}
 }
 
 // TODO DRY with popupAndSideBarListener
+// TODO DRY with splashListener
 function devtoolsListenerMaker(connectingPort) {
 	// DevTools connections come from the DevTools panel, but the panel is
 	// inspecting a particular web page, which has a different tab ID.
@@ -139,23 +149,33 @@ function devtoolsListenerMaker(connectingPort) {
 			case 'toggle-all-landmarks':
 				sendToActiveContentScriptIfExists(message)
 				break
+		case 'open-help':
+			browser.tabs.update({
+				url: browser.runtime.getURL('help.html')
+			})
+			break
+		case 'open-settings':
+			browser.runtime.openOptionsPage()
+			break
 			default:
 				throw Error(`Unknown message from DevTools: ${JSON.stringify(message)}`)
 		}
 	}
 }
 
+// TODO DRY with popupAndSideBarListener
+// TODO DRY with devToolsListener
 function splashListener(message, sendingPort) {
 	switch (message.name) {
 		case 'get-commands':
 			browser.commands.getAll(function(commands) {
 				sendingPort.postMessage({
-					name: 'splash-populate-commands',
+					name: 'populate-commands',
 					commands: commands
 				})
 			})
 			break
-		case 'splash-open-configure-shortcuts':
+		case 'open-configure-shortcuts':
 			browser.tabs.update({
 				// This should only appear on Chrome/Opera
 				url: BROWSER === 'chrome'
@@ -163,12 +183,12 @@ function splashListener(message, sendingPort) {
 					: 'opera://settings/keyboardShortcuts'
 			})
 			break
-		case 'splash-open-help':
+		case 'open-help':
 			browser.tabs.update({
 				url: browser.runtime.getURL('help.html')
 			})
 			break
-		case 'splash-open-settings':
+		case 'open-settings':
 			browser.runtime.openOptionsPage()
 			break
 		default:

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -149,14 +149,14 @@ function devtoolsListenerMaker(connectingPort) {
 			case 'toggle-all-landmarks':
 				sendToActiveContentScriptIfExists(message)
 				break
-		case 'open-help':
-			browser.tabs.update({
-				url: browser.runtime.getURL('help.html')
-			})
-			break
-		case 'open-settings':
-			browser.runtime.openOptionsPage()
-			break
+			case 'open-help':
+				browser.tabs.update({
+					url: browser.runtime.getURL('help.html')
+				})
+				break
+			case 'open-settings':
+				browser.runtime.openOptionsPage()
+				break
 			default:
 				throw Error(`Unknown message from DevTools: ${JSON.stringify(message)}`)
 		}

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -20,20 +20,21 @@ let port = null
 // an error, let the user know.
 function handleLandmarksMessage(data) {
 	const display = document.getElementById('landmarks')
+	const showAllContainer = document.getElementById('show-all-container')
 	removeChildNodes(display)
 
 	// Content script would normally send back an array of landmarks
 	if (Array.isArray(data)) {
 		if (data.length === 0) {
 			addText(display, browser.i18n.getMessage('noLandmarksFound'))
-			document.getElementById('show-all').setAttribute('hidden', '')
+			showAllContainer.setAttribute('hidden', '')
 		} else {
 			makeLandmarksTree(data, display)
-			document.getElementById('show-all').removeAttribute('hidden')
+			showAllContainer.removeAttribute('hidden')
 		}
 	} else {
 		addText(display, browser.i18n.getMessage('errorNoConnection'))
-		document.getElementById('show-all').setAttribute('hidden', '')
+		showAllContainer.setAttribute('hidden', '')
 	}
 }
 

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -1,4 +1,5 @@
 import './compatibility'
+import translate from './translate'
 import landmarkName from './landmarkName'
 import { defaultInterfaceSettings, dismissalStates } from './defaults'
 import disconnectingPortErrorCheck from './disconnectingPortErrorCheck'
@@ -290,11 +291,7 @@ if (INTERFACE === 'sidebar') {
 // When the pop-up (or sidebar) opens, translate the heading and grab and
 // process the list of page landmarks
 function main() {
-	document.getElementById('heading').innerText =
-		browser.i18n.getMessage('popupHeading')
-
-	document.getElementById('show-all-label').appendChild(document
-		.createTextNode(browser.i18n.getMessage('popupShowAllLandmarks')))
+	translate()
 
 	if (INTERFACE === 'devtools') {
 		port = browser.runtime.connect({ name: INTERFACE })

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -344,6 +344,20 @@ function main() {
 	port.postMessage({ name: 'get-toggle-state' })
 
 	document.getElementById('show-all').addEventListener('change', flipToggle)
+
+	document.getElementById('help').onclick = function() {
+		port.postMessage({ name: 'open-help' })
+		if (INTERFACE === 'popup') {
+			window.close()
+		}
+	}
+
+	document.getElementById('settings').onclick = function() {
+		port.postMessage({ name: 'open-settings' })
+		if (INTERFACE === 'popup') {
+			window.close()
+		}
+	}
 }
 
 main()

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -26,14 +26,14 @@ function handleLandmarksMessage(data) {
 	if (Array.isArray(data)) {
 		if (data.length === 0) {
 			addText(display, browser.i18n.getMessage('noLandmarksFound'))
-			document.getElementById('show-all-label').setAttribute('hidden', '')
+			document.getElementById('show-all').setAttribute('hidden', '')
 		} else {
 			makeLandmarksTree(data, display)
-			document.getElementById('show-all-label').removeAttribute('hidden')
+			document.getElementById('show-all').removeAttribute('hidden')
 		}
 	} else {
 		addText(display, browser.i18n.getMessage('errorNoConnection'))
-		document.getElementById('show-all-label').setAttribute('hidden', '')
+		document.getElementById('show-all').setAttribute('hidden', '')
 	}
 }
 
@@ -236,7 +236,8 @@ if (INTERFACE === 'sidebar') {
 				note.appendChild(para)
 				note.appendChild(buttons)
 
-				document.body.insertBefore(note, document.body.firstChild)
+				const container = document.getElementById('container')
+				container.insertBefore(note, container.firstChild)
 			}
 		})
 	}

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -291,17 +291,32 @@ if (INTERFACE === 'sidebar') {
 // When the pop-up (or sidebar) opens, translate the heading and grab and
 // process the list of page landmarks
 function main() {
-	translate()
-
 	if (INTERFACE === 'devtools') {
+		document.getElementById('bottom').remove()
+
 		port = browser.runtime.connect({ name: INTERFACE })
 		port.postMessage({
 			name: 'init',
 			tabId: browser.devtools.inspectedWindow.tabId
 		})
 	} else {
+		// eslint-disable-next-line no-inner-declarations
+		function makeEventHandler(type) {
+			document.getElementById(type).onclick = function() {
+				port.postMessage({ name: `open-${type}` })
+				if (INTERFACE === 'popup') {
+					window.close()
+				}
+			}
+		}
+
+		makeEventHandler('help')
+		makeEventHandler('settings')
+
 		port = browser.runtime.connect({ name: INTERFACE })
 	}
+
+	translate()
 
 	port.onDisconnect.addListener(function() {
 		disconnectingPortErrorCheck()
@@ -341,20 +356,6 @@ function main() {
 	port.postMessage({ name: 'get-toggle-state' })
 
 	document.getElementById('show-all').addEventListener('change', flipToggle)
-
-	document.getElementById('help').onclick = function() {
-		port.postMessage({ name: 'open-help' })
-		if (INTERFACE === 'popup') {
-			window.close()
-		}
-	}
-
-	document.getElementById('settings').onclick = function() {
-		port.postMessage({ name: 'open-settings' })
-		if (INTERFACE === 'popup') {
-			window.close()
-		}
-	}
 }
 
 main()

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -238,8 +238,8 @@ if (INTERFACE === 'sidebar') {
 				note.appendChild(para)
 				note.appendChild(buttons)
 
-				const container = document.getElementById('container')
-				container.insertBefore(note, container.firstChild)
+				const content = document.getElementById('content')
+				content.insertBefore(note, content.firstChild)
 			}
 		})
 	}
@@ -288,11 +288,24 @@ if (INTERFACE === 'sidebar') {
 // Management
 //
 
+function makeEventHandlers(linkName) {
+	const link = document.getElementById(linkName)
+	const core = () => {
+		port.postMessage({ name: `open-${linkName}` })
+		if (INTERFACE === 'popup') window.close()
+	}
+
+	link.addEventListener('click', core)
+	link.addEventListener('keydown', function(event) {
+		if (event.key === 'Enter') core()
+	})
+}
+
 // When the pop-up (or sidebar) opens, translate the heading and grab and
 // process the list of page landmarks
 function main() {
 	if (INTERFACE === 'devtools') {
-		document.getElementById('bottom').remove()
+		document.getElementById('links').remove()
 
 		port = browser.runtime.connect({ name: INTERFACE })
 		port.postMessage({
@@ -300,18 +313,8 @@ function main() {
 			tabId: browser.devtools.inspectedWindow.tabId
 		})
 	} else {
-		// eslint-disable-next-line no-inner-declarations
-		function makeEventHandler(type) {
-			document.getElementById(type).onclick = function() {
-				port.postMessage({ name: `open-${type}` })
-				if (INTERFACE === 'popup') {
-					window.close()
-				}
-			}
-		}
-
-		makeEventHandler('help')
-		makeEventHandler('settings')
+		makeEventHandlers('help')
+		makeEventHandlers('settings')
 
 		port = browser.runtime.connect({ name: INTERFACE })
 	}

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -20,21 +20,21 @@ let port = null
 // an error, let the user know.
 function handleLandmarksMessage(data) {
 	const display = document.getElementById('landmarks')
-	const showAllContainer = document.getElementById('show-all-container')
+	const showAllContainer = document.getElementById('show-all-label')
 	removeChildNodes(display)
 
 	// Content script would normally send back an array of landmarks
 	if (Array.isArray(data)) {
 		if (data.length === 0) {
 			addText(display, browser.i18n.getMessage('noLandmarksFound'))
-			showAllContainer.setAttribute('hidden', '')
+			showAllContainer.style.display = 'none'
 		} else {
 			makeLandmarksTree(data, display)
-			showAllContainer.removeAttribute('hidden')
+			showAllContainer.style.display = null
 		}
 	} else {
 		addText(display, browser.i18n.getMessage('errorNoConnection'))
-		showAllContainer.setAttribute('hidden', '')
+		showAllContainer.style.display = 'none'
 	}
 }
 

--- a/src/code/_help.js
+++ b/src/code/_help.js
@@ -21,14 +21,14 @@ const keyboardShortcutsLink = {
 	listen: [{
 		event: 'click',
 		handler: () => port.postMessage({
-			name: 'splash-open-configure-shortcuts'
+			name: 'open-configure-shortcuts'
 		})
 	}, {
 		event: 'keydown',
 		handler: (event) => {
 			if (event.key === 'Enter') {
 				port.postMessage({
-					name: 'splash-open-configure-shortcuts'
+					name: 'open-configure-shortcuts'
 				})
 			}
 		}
@@ -44,7 +44,7 @@ const settingsLink = {
 		event: 'click',
 		handler: () => {
 			port.postMessage({
-				name: 'splash-open-settings'
+				name: 'open-settings'
 			})
 		}
 	}, {
@@ -52,7 +52,7 @@ const settingsLink = {
 		handler: (event) => {
 			if (event.key === 'Enter') {
 				port.postMessage({
-					name: 'splash-open-configure-shortcuts'
+					name: 'open-configure-shortcuts'
 				})
 			}
 		}
@@ -160,7 +160,7 @@ function firefoxShortcutElements(shortcut) {
 }
 
 function messageHandler(message) {  // also sendingPort
-	if (message.name !== 'splash-populate-commands') return
+	if (message.name !== 'populate-commands') return
 
 	// Chrome allows only four keyboard shortcuts to be specified in the
 	// manifest; Firefox allows many.

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -1,4 +1,5 @@
 import './compatibility'
+import translate from './translate'
 import { defaultSettings, dismissalStates } from './defaults'
 
 const options = [{
@@ -18,18 +19,6 @@ const options = [{
 	element: document.getElementById('debug-info'),
 	property: 'checked'
 }]
-
-// Translation
-// http://tumble.jeremyhubert.com/post/7076881720
-// HT http://stackoverflow.com/questions/25467009/
-function translateStuff() {
-	const objects = document.getElementsByTagName('*')
-	for(const object of objects) {
-		if (object.dataset && object.dataset.message) {
-			object.innerText = browser.i18n.getMessage(object.dataset.message)
-		}
-	}
-}
 
 function restoreOptions() {
 	browser.storage.sync.get(defaultSettings, function(items) {
@@ -139,7 +128,7 @@ function main() {
 		})
 	}
 
-	translateStuff()
+	translate()
 	restoreOptions()
 	setUpOptionHandlers()
 }

--- a/src/code/translate.js
+++ b/src/code/translate.js
@@ -1,0 +1,8 @@
+// http://tumble.jeremyhubert.com/post/7076881720
+// HT http://stackoverflow.com/questions/25467009/
+export default function translate() {
+	for(const element of document.querySelectorAll('[data-message]')) {
+		element.appendChild(document.createTextNode(
+			browser.i18n.getMessage(element.dataset.message)))
+	}
+}

--- a/src/static/addHelpLinkToHomePage.js
+++ b/src/static/addHelpLinkToHomePage.js
@@ -13,7 +13,7 @@ link.href = '#'
 link.onclick = function() {
 	const port = browser.runtime.connect({ name: 'splash' })
 	port.postMessage({
-		name: 'splash-open-help'
+		name: 'open-help'
 	})
 	port.disconnect()
 }

--- a/src/static/gui.css
+++ b/src/static/gui.css
@@ -3,22 +3,40 @@
 }
 
 body {
-	padding: calc(var(--spacing) * 2);
+	margin: 0 !important;  /* https://stackoverflow.com/a/37425269/1485308 */
+	min-width: 12em;       /* for Chrome-like browsers */
 	font-family: sans-serif;
+	background-color: #eee;
+	display: flex;
+	flex-direction: column;
+}
+
+#container {
+	outline: 1px solid purple;
+	padding: calc(var(--spacing) * 2);
+	background-color: #eef;
+	flex-grow: 1;
 }
 
 h1 {
+	outline: 1px solid purple;
 	font-size: 1em;
-	padding: var(--spacing);
 	margin: 0;
+	margin-bottom: calc(var(--spacing) * 4);
 }
 
-p {
+p, #show-all {
+	outline: 1px solid purple;
 	margin: 0;
-	padding: var(--spacing);
+	margin-bottom: calc(var(--spacing) * 4);
+}
+
+#show-all {
+	margin-top: calc(var(--spacing) * 4);
 }
 
 ul {
+	outline: 1px solid purple;
 	margin: 0;
 	padding: 0;
 }
@@ -32,47 +50,25 @@ li {
 }
 
 button {
-	margin: var(--spacing);
+	margin: 0;
+	margin-bottom: var(--spacing);
 	height: auto;         /* stops Firefox causing overflows on Windows
-	                         https://github.com/matatk/landmarks/issues/149 */
+	https://github.com/matatk/landmarks/issues/149 */
 	padding-left: 0.5em;  /* These are needed due to the above */
 	padding-right: 0.5em;
 	padding-top: 0.25em;
 	padding-bottom: 0.25em;
 }
 
-label {
-	margin-top: calc(var(--spacing) * 2);
-}
-
-/* ui */
-:root {
-	--light: #e4fbf0;
-	--vivid: #159957;
-}
-
-#note {
-	margin-bottom: calc(var(--spacing) * 2);
-	background-color: var(--light);
-	border: 1px solid var(--vivid);
-	border-radius: 1em;
-}
-
-#note p {
-	padding: 0.5em;
-	padding-top: 0.75em;
-}
-
-#note div {
+#bottom {
+	outline: 1px solid purple;
 	display: flex;
-	flex-direction: column;
 }
 
-#note button {
+#bottom button {
+	font-size: inherit;
+	outline: 1px solid gray;
+	margin: 0;
 	flex-grow: 1;
-	border-color: var(--vivid);
-	background-color: var(--light);
-	border-radius: 1em;
 	text-align: center;
 }
-/* /ui */

--- a/src/static/gui.css
+++ b/src/static/gui.css
@@ -71,5 +71,5 @@ button {
 }
 
 #links a:focus, #links a:hover {
-	border: 2px solid blue;
+	border: 1px solid blue;
 }

--- a/src/static/gui.css
+++ b/src/static/gui.css
@@ -6,13 +6,10 @@ body {
 	margin: 0 !important;  /* https://stackoverflow.com/a/37425269/1485308 */
 	min-width: 12em;       /* for Chrome-like browsers */
 	font-family: sans-serif;
-	display: flex;
-	flex-direction: column;
 }
 
-#container {
+#content {
 	padding: calc(var(--spacing) * 2);
-	flex-grow: 1;
 }
 
 h1 {
@@ -55,13 +52,24 @@ button {
 	padding-bottom: 0.25em;
 }
 
-#bottom {
+#links {
 	display: flex;
 }
 
-#bottom button {
-	font-size: inherit;
+#links a {
+	display: block;
 	margin: 0;
+	background-color: #eee;
+	border: 1px solid gray;
 	flex-grow: 1;
 	text-align: center;
+
+	padding-left: 0.5em;
+	padding-right: 0.5em;
+	padding-top: 0.25em;
+	padding-bottom: 0.25em;
+}
+
+#links a:focus, #links a:hover {
+	border: 2px solid blue;
 }

--- a/src/static/gui.css
+++ b/src/static/gui.css
@@ -2,10 +2,6 @@
 	--spacing: 0.25em;
 }
 
-* {
-	box-sizing: border-box;  /* TODO: needed? */
-}
-
 body {
 	margin: 0 !important;  /* https://stackoverflow.com/a/37425269/1485308 */
 	min-width: 12em;       /* for Chrome-like browsers */
@@ -25,12 +21,13 @@ h1 {
 	margin-bottom: calc(var(--spacing) * 4);
 }
 
-p, #show-all-container {
+p, #show-all-label {
 	margin: 0;
 	margin-bottom: calc(var(--spacing) * 2);
 }
 
-#show-all-container {
+#show-all-label {
+	display: block;
 	margin-top: calc(var(--spacing) * 2);
 }
 

--- a/src/static/gui.css
+++ b/src/static/gui.css
@@ -25,12 +25,12 @@ h1 {
 	margin-bottom: calc(var(--spacing) * 4);
 }
 
-p, #show-all {
+p, #show-all-container {
 	margin: 0;
 	margin-bottom: calc(var(--spacing) * 2);
 }
 
-#show-all {
+#show-all-container {
 	margin-top: calc(var(--spacing) * 2);
 }
 

--- a/src/static/gui.css
+++ b/src/static/gui.css
@@ -27,11 +27,11 @@ h1 {
 
 p, #show-all {
 	margin: 0;
-	margin-bottom: calc(var(--spacing) * 4);
+	margin-bottom: calc(var(--spacing) * 2);
 }
 
 #show-all {
-	margin-top: calc(var(--spacing) * 4);
+	margin-top: calc(var(--spacing) * 2);
 }
 
 ul {

--- a/src/static/gui.css
+++ b/src/static/gui.css
@@ -2,31 +2,30 @@
 	--spacing: 0.25em;
 }
 
+* {
+	box-sizing: border-box;  /* TODO: needed? */
+}
+
 body {
 	margin: 0 !important;  /* https://stackoverflow.com/a/37425269/1485308 */
 	min-width: 12em;       /* for Chrome-like browsers */
 	font-family: sans-serif;
-	background-color: #eee;
 	display: flex;
 	flex-direction: column;
 }
 
 #container {
-	outline: 1px solid purple;
 	padding: calc(var(--spacing) * 2);
-	background-color: #eef;
 	flex-grow: 1;
 }
 
 h1 {
-	outline: 1px solid purple;
 	font-size: 1em;
 	margin: 0;
 	margin-bottom: calc(var(--spacing) * 4);
 }
 
 p, #show-all {
-	outline: 1px solid purple;
 	margin: 0;
 	margin-bottom: calc(var(--spacing) * 4);
 }
@@ -36,7 +35,6 @@ p, #show-all {
 }
 
 ul {
-	outline: 1px solid purple;
 	margin: 0;
 	padding: 0;
 }
@@ -61,13 +59,11 @@ button {
 }
 
 #bottom {
-	outline: 1px solid purple;
 	display: flex;
 }
 
 #bottom button {
 	font-size: inherit;
-	outline: 1px solid gray;
 	margin: 0;
 	flex-grow: 1;
 	text-align: center;

--- a/src/static/sidebar.css
+++ b/src/static/sidebar.css
@@ -1,0 +1,39 @@
+:root {
+	--light: #e4fbf0;
+	--vivid: #159957;
+}
+
+html {
+	height: 100%;
+}
+
+body {
+	height: 100%;
+}
+
+#note {
+	outline: 1px solid purple;
+	margin-bottom: calc(var(--spacing) * 4);
+	background-color: var(--light);
+	border: 1px solid var(--vivid);
+	border-radius: 1em;
+}
+
+#note p {
+	margin: calc(var(--spacing) * 3);
+}
+
+#note div {
+	margin: calc(var(--spacing) * 3);
+	outline: 1px solid purple;
+	display: flex;
+	flex-direction: column;
+}
+
+#note button {
+	outline: 1px solid purple;
+	border-color: var(--vivid);
+	background-color: var(--light);
+	border-radius: 1em;
+	text-align: center;
+}

--- a/src/static/sidebar.css
+++ b/src/static/sidebar.css
@@ -9,6 +9,12 @@ html {
 
 body {
 	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
+#content {
+	flex-grow: 1;
 }
 
 #note {

--- a/src/static/sidebar.css
+++ b/src/static/sidebar.css
@@ -12,7 +12,6 @@ body {
 }
 
 #note {
-	outline: 1px solid purple;
 	margin-bottom: calc(var(--spacing) * 4);
 	background-color: var(--light);
 	border: 1px solid var(--vivid);
@@ -25,13 +24,11 @@ body {
 
 #note div {
 	margin: calc(var(--spacing) * 3);
-	outline: 1px solid purple;
 	display: flex;
 	flex-direction: column;
 }
 
 #note button {
-	outline: 1px solid purple;
 	border-color: var(--vivid);
 	background-color: var(--light);
 	border-radius: 1em;


### PR DESCRIPTION
This makes Help and Preferences more discoverable. It involved renaming some messages for clarity, factoring out translation and also improving the styles somewhat, including having slight differences on the sidebar styles (to make it fill height). The links don't show up in the DevTools panel.

When the stand-alone options page is done, there should be a big refactoring and harmonisation of styles across options, GUIs and help.

Fixes #250.