### PR TITLE
build: Mozilla Add-ons build information script

### DIFF
--- a/meta/amo-info-and-download.sh
+++ b/meta/amo-info-and-download.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+in='meta/amo-info.template'
+tag=$(git describe --tags --abbrev=0)
+changelog_line=$(grep $tag CHANGELOG.md)
+changelog_date=$(echo "$changelog_line" | egrep -o '\d{4}-\d{2}-\d{2}')
+tag_without_dots=$(echo $tag | tr -d .)
+changelog_anchor="$tag_without_dots-$changelog_date"
+
+cat $in | sed \
+	-e "s/CHANGELOG_ANCHOR/$changelog_anchor/g" \
+	-e "s/VERSION_NUMBER/$tag/g"
+
+echo
+github_code_url="https://github.com/matatk/landmarks/archive/$tag.zip"
+curl --remote-name --remote-header-name --location $github_code_url

--- a/meta/amo-info.template
+++ b/meta/amo-info.template
@@ -1,0 +1,21 @@
+Changes in this release: https://github.com/matatk/landmarks/blob/master/CHANGELOG.md#CHANGELOG_ANCHOR
+
+Thanks for your review :-).
+
+Landmarks uses a build process. There's no obfuscation or minification, but Rollup is used to turn ES6 modules into combined script files, and a tool is used to convert an SVG logo into several PNG files. Build information follows.
+
+The attached source is from the VERSION_NUMBER tag: <https://github.com/matatk/landmarks/releases/tag/VERSION_NUMBER>
+
+Required software for the build:
+
+* git - needed to fetch my "one-svg-to-many-sized-pngs" node package from GitHub.
+* Node and npm.
+
+To build for Firefox specifically:
+
+1. npm install
+2. npm run build:firefox
+
+You'll find the extension in the build/firefox/ directory.
+
+Please note: the build process has only been extensively tested on macOS. It runs on Windows and should be fine there and on Linux, but if you have any problems and are able to check on macOS, please do.


### PR DESCRIPTION
This adds a template build instructions file, and a shell script that fills in the latest tag information and downloads the source code ZIP from GitHub, for submission to AMO.

Closes #252