### PR TITLE
fix: Change "show all landmarks" key to avoid Firefox clash

### DIFF
--- a/src/assemble/manifest.firefox.json
+++ b/src/assemble/manifest.firefox.json
@@ -39,7 +39,7 @@
   "commands": {
     "toggle-all-landmarks": {
       "suggested_key": {
-        "default": "Alt+Shift+S"
+        "default": "Alt+Shift+A"
       }
     }
   }


### PR DESCRIPTION
Change the combo to Alt+Shift+A from Alt+Shift+S, which opens the History menu on Windows.

Fixes #251