### PR TITLE
build: Use path.join() more

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -306,14 +306,14 @@ function mergeMessages(browser) {
 
 	if (browser === 'firefox' || browser === 'opera') {
 		const ui = path.join(srcAssembleDir, 'messages.interface.json')
-		const commonJson = require('../' + common)  // TODO check Windows
-		const uiJson = require('../' + ui)          // TODO check Windows
+		const commonJson = require(path.join('..', common))
+		const uiJson = require(path.join('..', ui))
 		const merged = merge(commonJson, uiJson)
 		fs.writeFileSync(destinationFile, JSON.stringify(merged, null, 2))
 	} else {
 		// Instead of just copying the common file, write it in the same way as
 		// the merged one, so that diffs between builds are minimal.
-		const commonJson = require('../' + common)
+		const commonJson = require(path.join('..', common))
 		fs.writeFileSync(destinationFile, JSON.stringify(commonJson, null, 2))
 	}
 

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -382,7 +382,8 @@ function checkBrowserActionState(tabId, url) {
 //
 // TODO: In some circumstances (most GitHub transitions, this fires two times on
 //       Firefox and three times on Chrome. For YouTube, some transitions only
-//       cause this to fire once. Need to investigate this more...
+//       cause this to fire once. Could it be to do with
+//       <https://developer.chrome.com/extensions/background_pages#filters>?
 browser.webNavigation.onHistoryStateUpdated.addListener(function(details) {
 	if (details.frameId > 0) return
 	if (contentConnections.hasOwnProperty(activeTabId)) {  // could be special page


### PR DESCRIPTION
There was no problem on Windows, but this is neater.

Also cheekily adds a note to a FIXME in the background script that might help solve it later.