### PR TITLE
fix: Support migration of user settings; Remove the debugInfo setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
     "profile-guarding": "node scripts/profile-guarding.js",
     "start:firefox": "web-ext run --browser-console --source-dir build/firefox/",
     "pretest": "eslint .",
-    "test": "npm run test:landmarks && npm run test:contrast",
+    "test": "npm run test:landmarks && npm run test:contrast && npm run test:migration-manager",
     "pretest:contrast": "rollup src/code/contrastChecker.js -f cjs > test/test-code-in-harness-contrast.js",
     "test:contrast": "node test/test-contrast.js",
     "pretest:landmarks": "rollup src/code/landmarksFinder.js -f cjs > test/test-code-in-harness-landmarks.js",
     "test:landmarks": "node test/test-landmarks.js",
+    "pretest:migration-manager": "rollup src/code/migrationManager.js -f cjs > test/test-code-in-harness-migration-manager.js",
+    "test:migration-manager": "node test/test-migration-manager.js",
     "version": "npm run _changelog && git add CHANGELOG.md"
   },
   "husky": {

--- a/src/assemble/messages.common.json
+++ b/src/assemble/messages.common.json
@@ -92,14 +92,6 @@
     "message": "Border label font size (pixels):"
   },
 
-  "prefsDeveloper": {
-    "message": "Debugging"
-  },
-
-  "prefsDebugInfo": {
-    "message": "Show debugging info in the console"
-  },
-
   "prefsResetAll": {
     "message": "Reset settings to defaults"
   },

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -351,13 +351,17 @@ const migrationManager = new MigrationManager({
 })
 
 browser.storage.sync.get(null, function(items) {
-	migrationManager.migrate(items)
-	browser.storage.sync.clear(function() {
-		browser.storage.sync.set(items, function() {
-			// Debugging
-			browser.storage.sync.get(null, function(newItems) {
-				console.log('Landmarks new settings:', newItems)
+	const didMigration = migrationManager.migrate(items)
+	if (didMigration) {
+		browser.storage.sync.clear(function() {
+			browser.storage.sync.set(items, function() {
+				// Debugging
+				browser.storage.sync.get(null, function(newItems) {
+					console.log('Landmarks new settings:', newItems)
+				})
 			})
 		})
-	})
+	} else {
+		console.log('Landmarks: migration not needed')
+	}
 })

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -354,14 +354,7 @@ browser.storage.sync.get(null, function(items) {
 	const didMigration = migrationManager.migrate(items)
 	if (didMigration) {
 		browser.storage.sync.clear(function() {
-			browser.storage.sync.set(items, function() {
-				// Debugging
-				browser.storage.sync.get(null, function(newItems) {
-					console.log('Landmarks new settings:', newItems)
-				})
-			})
+			browser.storage.sync.set(items)
 		})
-	} else {
-		console.log('Landmarks: migration not needed')
 	}
 })

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -14,10 +14,6 @@ const options = [{
 	name: 'borderFontSize',
 	element: document.getElementById('border-font-size'),
 	property: 'value'
-}, {
-	name: 'debugInfo',
-	element: document.getElementById('debug-info'),
-	property: 'checked'
 }]
 
 function restoreOptions() {

--- a/src/code/defaults.js
+++ b/src/code/defaults.js
@@ -8,10 +8,6 @@ export const defaultBorderSettings = Object.freeze({
 	borderFontSize: '16'
 })
 
-export const defaultDebugSettings = Object.freeze({
-	debugInfo: false
-})
-
 export const defaultInterfaceSettings =
 	(BROWSER === 'firefox' || BROWSER === 'opera')
 		? Object.freeze({ interface: 'popup' })
@@ -21,11 +17,8 @@ export const defaultSettings =
 	(BROWSER === 'firefox' || BROWSER === 'opera')
 		? Object.freeze(Object.assign({},
 			defaultBorderSettings,
-			defaultDebugSettings,
 			defaultInterfaceSettings))
-		: Object.freeze(Object.assign({},
-			defaultBorderSettings,
-			defaultDebugSettings))
+		: Object.freeze(defaultBorderSettings)
 
 
 //

--- a/src/code/migrationManager.js
+++ b/src/code/migrationManager.js
@@ -13,7 +13,6 @@ export default function MigrationManager(migrations) {
 	this.migrate = function(settings) {
 		const startingVersion = getVersion(settings)
 		if (isMigrationNeeded(startingVersion)) {
-			console.log('Landmarks settings pre-migration:', settings)
 			for (const key in migrations) {
 				const toVersion = Number(key)
 				if (toVersion > startingVersion) {
@@ -21,8 +20,7 @@ export default function MigrationManager(migrations) {
 					settings.version = toVersion
 				}
 			}
-			console.log('Landmarks settings post-migration:', settings)
-			console.log(`Landmarks: migrated from ${startingVersion} to ${settings.version}`)
+			console.log(`Landmarks: migrated settings from version ${startingVersion} to version ${settings.version}`)
 			return true
 		}
 		return false

--- a/src/code/migrationManager.js
+++ b/src/code/migrationManager.js
@@ -13,6 +13,7 @@ export default function MigrationManager(migrations) {
 	this.migrate = function(settings) {
 		const startingVersion = getVersion(settings)
 		if (isMigrationNeeded(startingVersion)) {
+			console.log('Landmarks settings pre-migration:', settings)
 			for (const key in migrations) {
 				const toVersion = Number(key)
 				if (toVersion > startingVersion) {
@@ -20,6 +21,8 @@ export default function MigrationManager(migrations) {
 					settings.version = toVersion
 				}
 			}
+			console.log('Landmarks settings post-migration:', settings)
+			console.log(`Landmarks: migrated from ${startingVersion} to ${settings.version}`)
 		}
 	}
 }

--- a/src/code/migrationManager.js
+++ b/src/code/migrationManager.js
@@ -24,5 +24,6 @@ export default function MigrationManager(migrations) {
 			console.log('Landmarks settings post-migration:', settings)
 			console.log(`Landmarks: migrated from ${startingVersion} to ${settings.version}`)
 		}
+		return false
 	}
 }

--- a/src/code/migrationManager.js
+++ b/src/code/migrationManager.js
@@ -1,0 +1,25 @@
+export default function MigrationManager(migrations) {
+	function getVersion(settings) {
+		if (!settings.hasOwnProperty('version')) {
+			return 0
+		}
+		return settings.version
+	}
+
+	function isMigrationNeeded(startingVersion) {
+		return startingVersion < Object.keys(migrations).pop()
+	}
+
+	this.migrate = function(settings) {
+		const startingVersion = getVersion(settings)
+		if (isMigrationNeeded(startingVersion)) {
+			for (const key in migrations) {
+				const toVersion = Number(key)
+				if (toVersion > startingVersion) {
+					migrations[toVersion](settings)
+					settings.version = toVersion
+				}
+			}
+		}
+	}
+}

--- a/src/code/migrationManager.js
+++ b/src/code/migrationManager.js
@@ -23,6 +23,7 @@ export default function MigrationManager(migrations) {
 			}
 			console.log('Landmarks settings post-migration:', settings)
 			console.log(`Landmarks: migrated from ${startingVersion} to ${settings.version}`)
+			return true
 		}
 		return false
 	}

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -44,16 +44,9 @@
 		</div>
 		<!-- /ui -->
 
-		<details>
-			<summary data-message="prefsDeveloper"></summary>
-			<div class="browser-style input-first">
-				<input id="debug-info" type="checkbox">
-				<label for="debug-info" data-message="prefsDebugInfo"></label>
-			</div>
-			<div class="input-first">
-				<button id="reset-to-defaults" data-message="prefsResetAll" class="browser-style"></button>
-			</div>
-		</details>
+		<div class="input-first"> <!-- TODO: remove? Would remove bottom -->
+			<button id="reset-to-defaults" data-message="prefsResetAll" class="browser-style"></button>
+		</div>
 
 		<script src="options.js"></script>
 	</body>

--- a/test/test-migration-manager.js
+++ b/test/test-migration-manager.js
@@ -72,6 +72,18 @@ exports['test two migrations, only one needed, error path'] = function(assert) {
 	assert.strictEqual(settings.newNewSetting, true, 'added new new setting')
 }
 
+exports['test returns false when migration not necessary'] = function(assert) {
+	const settings = { version: 1 }
+	const migrations = {
+		1: function() {
+			throw new Error('This should not be run')
+		}
+	}
+	const migrationManager = new MigrationManager(migrations)
+	const result = migrationManager.migrate(settings)
+	assert.strictEqual(result, false, 'migration not needed')
+}
+
 if (module === require.main) {
 	require('test').run(exports)
 }

--- a/test/test-migration-manager.js
+++ b/test/test-migration-manager.js
@@ -1,29 +1,7 @@
 'use strict'
-function MigrationManager(migrations) {
-	function getVersion(settings) {
-		if (!settings.hasOwnProperty('version')) {
-			return 0
-		}
-		return settings.version
-	}
-
-	function isMigrationNeeded(startingVersion) {
-		return startingVersion < Object.keys(migrations).pop()
-	}
-
-	this.migrate = function(settings) {
-		const startingVersion = getVersion(settings)
-		if (isMigrationNeeded(startingVersion)) {
-			for (const key in migrations) {
-				const toVersion = Number(key)
-				if (toVersion > startingVersion) {
-					migrations[toVersion](settings)
-					settings.version = toVersion
-				}
-			}
-		}
-	}
-}
+const path = require('path')
+const MigrationManager = require(
+	path.join(__dirname, 'test-code-in-harness-migration-manager.js'))
 
 exports['test the damage report machine'] = function(assert) {
 	assert.ok(true, 'damage report machine intact')

--- a/test/test-migration-manager.js
+++ b/test/test-migration-manager.js
@@ -84,6 +84,16 @@ exports['test returns false when migration not necessary'] = function(assert) {
 	assert.strictEqual(result, false, 'migration not needed')
 }
 
+exports['test returns true when migration is necessary'] = function(assert) {
+	const settings = {}
+	const migrations = {
+		1: function() {}
+	}
+	const migrationManager = new MigrationManager(migrations)
+	const result = migrationManager.migrate(settings)
+	assert.strictEqual(result, true, 'migration was needed')
+}
+
 if (module === require.main) {
 	require('test').run(exports)
 }

--- a/test/test-migrations.js
+++ b/test/test-migrations.js
@@ -1,0 +1,124 @@
+'use strict'
+function getSettingsVersion(settings) {
+	if (!settings.hasOwnProperty('version')) {
+		return 0
+	}
+	return settings.version
+}
+
+function runMigrations(migrations, settings) {
+	const startingVersion = getSettingsVersion(settings)
+	for (const key in migrations) {
+		const toVersion = Number(key)
+		if (toVersion > startingVersion) {
+			migrations[toVersion](settings)
+			settings.version = toVersion
+		}
+	}
+}
+
+function isMigrationNeeded(migrations, startingVersion) {
+	return startingVersion < Object.keys(migrations).pop()
+}
+
+exports['test the damage report machine'] = function(assert) {
+	assert.ok(true, 'damage report machine intact')
+}
+
+exports['test implicit v0'] = function(assert) {
+	const settings = {}
+	assert.strictEqual(getSettingsVersion(settings), 0, 'ok')
+}
+
+exports['test explicit v0'] = function(assert) {
+	const settings = { 'version': 0 }
+	assert.strictEqual(getSettingsVersion(settings), 0, 'ok')
+}
+
+exports['test explicit v42'] = function(assert) {
+	const settings = { 'version': 42 }
+	assert.strictEqual(getSettingsVersion(settings), 42, 'ok')
+}
+
+exports['test one migration that adds a field'] = function(assert) {
+	const settings = { 'version': 0 }
+	const migrations = {
+		1: function(settings) {
+			settings['newSetting'] = true
+		}
+	}
+	runMigrations(migrations, settings)
+	assert.strictEqual(getSettingsVersion(settings), 1, 'bumped version')
+	assert.strictEqual(settings.newSetting, true, 'added new setting')
+}
+
+exports['test one migration that removes a field'] = function(assert) {
+	const settings = {
+		'version': 42,
+		'deprecatedSetting': 'orange'
+	}
+	const migrations = {
+		43: function(settings) {
+			delete settings.deprecatedSetting
+		}
+	}
+	runMigrations(migrations, settings)
+	assert.strictEqual(getSettingsVersion(settings), 43, 'bumped version')
+	assert.strictEqual(
+		settings.hasOwnProperty('deprecatedSetting'), false, 'removed setting')
+}
+
+exports['test two migrations'] = function(assert) {
+	const settings = { 'version': 0 }
+	const migrations = {
+		1: function(settings) {
+			settings['newSetting'] = true
+		},
+		2: function(settings) {
+			settings['newNewSetting'] = true
+		}
+	}
+	runMigrations(migrations, settings)
+	assert.strictEqual(getSettingsVersion(settings), 2, 'got latest version')
+	assert.strictEqual(settings.newSetting, true, 'added new setting')
+	assert.strictEqual(settings.newNewSetting, true, 'added new new setting')
+}
+
+exports['test two migrations, only one needed, error path'] = function(assert) {
+	// We're saying that we're starting with settings version 1, but we aren't.
+	const settings = { 'version': 1 }
+	const migrations = {
+		1: function(settings) {
+			settings['newSetting'] = true
+		},
+		2: function(settings) {
+			settings['newNewSetting'] = true
+		}
+	}
+	runMigrations(migrations, settings)
+	assert.strictEqual(getSettingsVersion(settings), 2, 'got latest version')
+	assert.strictEqual(settings.newSetting, undefined, "didn't run migration 1")
+	assert.strictEqual(settings.newNewSetting, true, 'added new new setting')
+}
+
+exports['test if migrations are needed (expecting no)'] = function(assert) {
+	const startingVersion = 1
+	const migrations = {
+		1: () => {}
+	}
+	assert.strictEqual(
+		isMigrationNeeded(migrations, startingVersion), false, 'no')
+}
+
+exports['test if migrations are needed (expecting yes)'] = function(assert) {
+	const startingVersion = 0
+	const migrations = {
+		1: () => {}
+	}
+	assert.strictEqual(
+		isMigrationNeeded(migrations, startingVersion), true, 'yes')
+}
+
+if (module === require.main) {
+	require('test').run(exports)
+}


### PR DESCRIPTION
* Add (test-driven) code for migrating the settings format to new versions.
* Use this to move to the next settings version, in which the debugInfo setting is removed.
* Remove the UI around the debugInfo setting.

**Background:** now that the mutation-tracking info is visible in the DevTools, and seems to work well, a lot of the existing console logging has been (and more will be) removed. If the user wants to get that info, they can open the DevTools panel. Therefore it seemed best to remove the setting that controlled the console logging.

The calls to `console.timeStamp()` will need to be kept, so that they can contribute to profiling recordings. This will need to be done by creating a debug build of the entire extension that can then be run with the profiling scripts, as `console.timeStamp()` always causes a corresponding `console.log()` *and* it doesn't seem possible to set any sort of "show debugging info" setting within an extension from a profile script. That will be done in a different PR.

**Scope notes:**
* This may feel a bit bigger than a "fix" but the `debugInfo` setting isn't really needed any more and thus shouldn't be user-visible (plus the Landmarks extension is a leaf in the dependency tree, so when it makes sense for users, it feels OK to prioritise them—if this were classified as a significant new version it could be confusing).
* The settings format has already changed, but I didn't previously have migration code. However, it was all additive up until now, so that is probably OK—in future, of course, I would start with the ability to migrate settings as a project developed.