### PR TITLE
fix: Ensure command descriptions appear on the help page on Firefox 66

### DIFF
--- a/src/assemble/manifest.firefox.json
+++ b/src/assemble/manifest.firefox.json
@@ -30,7 +30,7 @@
   "applications": {
     "gecko": {
       "id": "ariaLandmarkNav@ibm.com",
-      "strict_min_version": "62.0"
+      "strict_min_version": "66.0"
     }
   },
 

--- a/src/code/_help.js
+++ b/src/code/_help.js
@@ -96,18 +96,9 @@ function makeHTML(structure, root) {
 
 function addCommandRowAndReportIfMissing(command) {
 	// Work out the command's friendly name
-	let action
-
-	if (command.name === '_execute_browser_action') {
-		action = 'Show pop-up'
-	} else if (BROWSER === 'chrome' || BROWSER === 'opera') {
-		// Chrome returns the full descriptions
-		action = command.description
-	} else {
-		// Firefox requires the descriptions to be translated
-		const messageName = command.description.slice(6, -2)
-		action = browser.i18n.getMessage(messageName)
-	}
+	const action = command.name === '_execute_browser_action'
+		? 'Show pop-up'
+		: command.description
 
 	// Work out the command's shortcut
 	let shortcutCellElement


### PR DESCRIPTION
Closes #278