### PR TITLE
fix: Remove page visibility event listener when content script gets disconnected on Chrome-like browsers

### DIFF
--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -252,8 +252,9 @@ function bootstrap() {
 	if (BROWSER === 'chrome' || BROWSER === 'opera') {
 		browser.runtime.connect({ name: 'disconnect-checker' })
 			.onDisconnect.addListener(function() {
-				console.log('Landmarks: content script disconnected.')
+				console.log('Landmarks: content script disconnected due to extension unload/reload.')
 				observer.disconnect()
+				document.removeEventListener('visibilitychange', reflectPageVisibility, false)
 			})
 	}
 


### PR DESCRIPTION
Fixes #296