### PR TITLE
test: Expected test results in tree format

### DIFF
--- a/test/data/aria-labelledby-multiple-idrefs.json
+++ b/test/data/aria-labelledby-multiple-idrefs.json
@@ -1,31 +1,35 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "banner",
       "label": null,
-      "selector": "body > header"
+      "selector": "body > header",
+      "contains": [
+        {
+          "type": "landmark",
+          "role": "navigation",
+          "label": "World of wombats",
+          "selector": "body > header > nav"
+        }
+      ]
     },
     {
-      "depth": 1,
-      "role": "navigation",
-      "label": "World of wombats",
-      "selector": "body > header > nav"
-    },
-    {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": "Looking after your wombat",
-      "selector": "body > main"
+      "selector": "body > main",
+      "contains": [
+        {
+          "type": "landmark",
+          "role": "navigation",
+          "label": "Looking after your wombat Topics",
+          "selector": "body > main > nav:nth-child(2)"
+        }
+      ]
     },
     {
-      "depth": 1,
-      "role": "navigation",
-      "label": "Looking after your wombat Topics",
-      "selector": "body > main > nav:nth-child(2)"
-    },
-    {
-      "depth": 0,
+      "type": "landmark",
       "role": "contentinfo",
       "label": null,
       "selector": "body > footer"

--- a/test/data/aside-alone-is-recognised.json
+++ b/test/data/aside-alone-is-recognised.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "complementary",
       "label": null,
       "selector": "body > aside"

--- a/test/data/aside-aria-labelledby.json
+++ b/test/data/aside-aria-labelledby.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "complementary",
       "label": "And another thing...",
       "selector": "body > aside"

--- a/test/data/digital-publishing-roles.json
+++ b/test/data/digital-publishing-roles.json
@@ -1,148 +1,154 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "doc-part",
       "label": "Frontmatter",
-      "selector": "body > div:nth-child(3)"
+      "selector": "body > div:nth-child(3)",
+      "contains": [
+        {
+          "type": "landmark",
+          "role": "doc-toc",
+          "label": null,
+          "selector": "body > div:nth-child(3) > nav:nth-child(1)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-pagelist",
+          "label": null,
+          "selector": "body > div:nth-child(3) > nav:nth-child(2)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-preface",
+          "label": null,
+          "selector": "body > div:nth-child(3) > div:nth-child(3)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-foreword",
+          "label": null,
+          "selector": "body > div:nth-child(3) > div:nth-child(4)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-acknowledgements",
+          "label": null,
+          "selector": "body > div:nth-child(3) > div:nth-child(5)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-prologue",
+          "label": null,
+          "selector": "body > div:nth-child(3) > div:nth-child(6)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-introduction",
+          "label": null,
+          "selector": "body > div:nth-child(3) > div:nth-child(7)"
+        }
+      ]
     },
     {
-      "depth": 1,
-      "role": "doc-toc",
-      "label": null,
-      "selector": "body > div:nth-child(3) > nav:nth-child(1)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-pagelist",
-      "label": null,
-      "selector": "body > div:nth-child(3) > nav:nth-child(2)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-preface",
-      "label": null,
-      "selector": "body > div:nth-child(3) > div:nth-child(3)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-foreword",
-      "label": null,
-      "selector": "body > div:nth-child(3) > div:nth-child(4)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-acknowledgements",
-      "label": null,
-      "selector": "body > div:nth-child(3) > div:nth-child(5)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-prologue",
-      "label": null,
-      "selector": "body > div:nth-child(3) > div:nth-child(6)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-introduction",
-      "label": null,
-      "selector": "body > div:nth-child(3) > div:nth-child(7)"
-    },
-    {
-      "depth": 0,
+      "type": "landmark",
       "role": "doc-part",
       "label": "Mainmatter",
-      "selector": "body > div:nth-child(4)"
+      "selector": "body > div:nth-child(4)",
+      "contains": [
+        {
+          "type": "landmark",
+          "role": "doc-chapter",
+          "label": "Beginnings",
+          "selector": "body > div:nth-child(4) > section:nth-child(1)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-chapter",
+          "label": "Middles",
+          "selector": "body > div:nth-child(4) > section:nth-child(2)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-chapter",
+          "label": "Endings",
+          "selector": "body > div:nth-child(4) > section:nth-child(3)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-conclusion",
+          "label": null,
+          "selector": "body > div:nth-child(4) > section:nth-child(4)"
+        }
+      ]
     },
     {
-      "depth": 1,
-      "role": "doc-chapter",
-      "label": "Beginnings",
-      "selector": "body > div:nth-child(4) > section:nth-child(1)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-chapter",
-      "label": "Middles",
-      "selector": "body > div:nth-child(4) > section:nth-child(2)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-chapter",
-      "label": "Endings",
-      "selector": "body > div:nth-child(4) > section:nth-child(3)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-conclusion",
-      "label": null,
-      "selector": "body > div:nth-child(4) > section:nth-child(4)"
-    },
-    {
-      "depth": 0,
+      "type": "landmark",
       "role": "doc-part",
       "label": "Backmatter",
-      "selector": "body > div:nth-child(5)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-epilogue",
-      "label": null,
-      "selector": "body > div:nth-child(5) > div:nth-child(1)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-afterword",
-      "label": null,
-      "selector": "body > div:nth-child(5) > div:nth-child(2)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-endnotes",
-      "label": null,
-      "selector": "body > div:nth-child(5) > div:nth-child(3)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-bibliography",
-      "label": "References",
-      "selector": "body > div:nth-child(5) > div:nth-child(4)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-glossary",
-      "label": null,
-      "selector": "body > div:nth-child(5) > dl:nth-child(5)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-index",
-      "label": null,
-      "selector": "body > div:nth-child(5) > nav:nth-child(6)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-credits",
-      "label": null,
-      "selector": "body > div:nth-child(5) > div:nth-child(7)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-errata",
-      "label": null,
-      "selector": "body > div:nth-child(5) > div:nth-child(8)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-appendix",
-      "label": "Technical specification",
-      "selector": "body > div:nth-child(5) > div:nth-child(9)"
-    },
-    {
-      "depth": 1,
-      "role": "doc-appendix",
-      "label": "Detailed schematics",
-      "selector": "body > div:nth-child(5) > div:nth-child(10)"
+      "selector": "body > div:nth-child(5)",
+      "contains": [
+        {
+          "type": "landmark",
+          "role": "doc-epilogue",
+          "label": null,
+          "selector": "body > div:nth-child(5) > div:nth-child(1)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-afterword",
+          "label": null,
+          "selector": "body > div:nth-child(5) > div:nth-child(2)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-endnotes",
+          "label": null,
+          "selector": "body > div:nth-child(5) > div:nth-child(3)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-bibliography",
+          "label": "References",
+          "selector": "body > div:nth-child(5) > div:nth-child(4)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-glossary",
+          "label": null,
+          "selector": "body > div:nth-child(5) > dl:nth-child(5)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-index",
+          "label": null,
+          "selector": "body > div:nth-child(5) > nav:nth-child(6)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-credits",
+          "label": null,
+          "selector": "body > div:nth-child(5) > div:nth-child(7)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-errata",
+          "label": null,
+          "selector": "body > div:nth-child(5) > div:nth-child(8)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-appendix",
+          "label": "Technical specification",
+          "selector": "body > div:nth-child(5) > div:nth-child(9)"
+        },
+        {
+          "type": "landmark",
+          "role": "doc-appendix",
+          "label": "Detailed schematics",
+          "selector": "body > div:nth-child(5) > div:nth-child(10)"
+        }
+      ]
     }
   ]
 }

--- a/test/data/form-aria-label.json
+++ b/test/data/form-aria-label.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "form",
       "label": "Contact Us",
       "selector": "body > form"

--- a/test/data/form-aria-labelledby.json
+++ b/test/data/form-aria-labelledby.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "form",
       "label": "Report a Fault",
       "selector": "body > form"

--- a/test/data/header-containing-nav-nav-search.json
+++ b/test/data/header-containing-nav-nav-search.json
@@ -1,37 +1,41 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "banner",
       "label": null,
-      "selector": "body > header"
+      "selector": "body > header",
+      "contains": [
+        {
+          "type": "landmark",
+          "role": "navigation",
+          "label": null,
+          "selector": "body > header > nav:nth-child(1)"
+        },
+        {
+          "type": "landmark",
+          "role": "navigation",
+          "label": null,
+          "selector": "body > header > nav:nth-child(2)",
+          "contains": [
+            {
+              "type": "landmark",
+              "role": "search",
+              "label": null,
+              "selector": "body > header > nav:nth-child(2) > div"
+            }
+          ]
+        }
+      ]
     },
     {
-      "depth": 1,
-      "role": "navigation",
-      "label": null,
-      "selector": "body > header > nav:nth-child(1)"
-    },
-    {
-      "depth": 1,
-      "role": "navigation",
-      "label": null,
-      "selector": "body > header > nav:nth-child(2)"
-    },
-    {
-      "depth": 2,
-      "role": "search",
-      "label": null,
-      "selector": "body > header > nav:nth-child(2) > div"
-    },
-    {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": null,
       "selector": "body > main"
     },
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "contentinfo",
       "label": null,
       "selector": "body > footer"

--- a/test/data/hidden-by-css-display-none-inline.json
+++ b/test/data/hidden-by-css-display-none-inline.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": null,
       "selector": "body > main"

--- a/test/data/hidden-by-css-display-none-nested.json
+++ b/test/data/hidden-by-css-display-none-nested.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": null,
       "selector": "body > main"

--- a/test/data/hidden-by-css-display-none.json
+++ b/test/data/hidden-by-css-display-none.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": null,
       "selector": "body > main"

--- a/test/data/hidden-by-css-visibility-hidden.json
+++ b/test/data/hidden-by-css-visibility-hidden.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": null,
       "selector": "body > main"

--- a/test/data/hidden-by-html-hidden-attribute-nested.json
+++ b/test/data/hidden-by-html-hidden-attribute-nested.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": null,
       "selector": "body > main"

--- a/test/data/hidden-by-html-hidden-attribute.json
+++ b/test/data/hidden-by-html-hidden-attribute.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": null,
       "selector": "body > main"

--- a/test/data/landmark-role-on-body.json
+++ b/test/data/landmark-role-on-body.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "region",
       "label": "Unlikely to happen?",
       "selector": "body"

--- a/test/data/main-alone-is-recognised.json
+++ b/test/data/main-alone-is-recognised.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": null,
       "selector": "body > main"

--- a/test/data/main-aria-label.json
+++ b/test/data/main-aria-label.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": "Slartibartfast",
       "selector": "body > main"

--- a/test/data/main-aria-labelledby.json
+++ b/test/data/main-aria-labelledby.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": "Kate",
       "selector": "body > main"

--- a/test/data/nested-siblings.json
+++ b/test/data/nested-siblings.json
@@ -1,22 +1,24 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": null,
-      "selector": "body > main"
-    },
-    {
-      "depth": 1,
-      "role": "region",
-      "label": "Sibling One",
-      "selector": "body > main > div:nth-child(1) > div"
-    },
-    {
-      "depth": 1,
-      "role": "region",
-      "label": "Sibling Two",
-      "selector": "body > main > div:nth-child(2) > div"
+      "selector": "body > main",
+      "contains": [
+        {
+          "type": "landmark",
+          "role": "region",
+          "label": "Sibling One",
+          "selector": "body > main > div:nth-child(1) > div"
+        },
+        {
+          "type": "landmark",
+          "role": "region",
+          "label": "Sibling Two",
+          "selector": "body > main > div:nth-child(2) > div"
+        }
+      ]
     }
   ]
 }

--- a/test/data/nesting-depth-restoration.json
+++ b/test/data/nesting-depth-restoration.json
@@ -1,31 +1,35 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "banner",
       "label": null,
       "selector": "body > header"
     },
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": null,
-      "selector": "body > main"
+      "selector": "body > main",
+      "contains": [
+        {
+          "type": "landmark",
+          "role": "region",
+          "label": "Outer section header",
+          "selector": "body > main > section",
+          "contains": [
+            {
+              "type": "landmark",
+              "role": "region",
+              "label": "Inner section header",
+              "selector": "body > main > section > section"
+            }
+          ]
+        }
+      ]
     },
     {
-      "depth": 1,
-      "role": "region",
-      "label": "Outer section header",
-      "selector": "body > main > section"
-    },
-    {
-      "depth": 2,
-      "role": "region",
-      "label": "Inner section header",
-      "selector": "body > main > section > section"
-    },
-    {
-      "depth": 0,
+      "type": "landmark",
       "role": "contentinfo",
       "label": null,
       "selector": "body > footer"

--- a/test/data/prefer-aria-labelledby.json
+++ b/test/data/prefer-aria-labelledby.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": "Kate",
       "selector": "body > main"

--- a/test/data/region-aria-label.json
+++ b/test/data/region-aria-label.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "region",
       "label": "Reluctant Region",
       "selector": "body > div"

--- a/test/data/region-aria-labelledby.json
+++ b/test/data/region-aria-labelledby.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "region",
       "label": "A Good Region",
       "selector": "body > div"

--- a/test/data/roles-land.json
+++ b/test/data/roles-land.json
@@ -1,37 +1,39 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "banner",
       "label": null,
       "selector": "#banner"
     },
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "navigation",
       "label": null,
       "selector": "#navigation"
     },
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": null,
       "selector": "#main"
     },
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "complementary",
       "label": null,
-      "selector": "#complementary"
+      "selector": "#complementary",
+      "contains": [
+        {
+          "type": "landmark",
+          "role": "search",
+          "label": null,
+          "selector": "#search"
+        }
+      ]
     },
     {
-      "depth": 1,
-      "role": "search",
-      "label": null,
-      "selector": "#search"
-    },
-    {
-      "depth": 0,
+      "type": "landmark",
       "role": "contentinfo",
       "label": null,
       "selector": "#contentinfo"

--- a/test/data/section-aria-label.json
+++ b/test/data/section-aria-label.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "region",
       "label": "Naughty invisible label",
       "selector": "body > section"

--- a/test/data/section-aria-labelledby.json
+++ b/test/data/section-aria-labelledby.json
@@ -1,7 +1,7 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "region",
       "label": "All About Apples",
       "selector": "body > section"

--- a/test/data/structural-elements.json
+++ b/test/data/structural-elements.json
@@ -1,31 +1,31 @@
 {
   "expected": [
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "banner",
       "label": null,
       "selector": "body > header"
     },
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "complementary",
       "label": null,
       "selector": "body > aside"
     },
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "navigation",
       "label": null,
       "selector": "body > nav"
     },
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "main",
       "label": null,
       "selector": "body > main"
     },
     {
-      "depth": 0,
+      "type": "landmark",
       "role": "contentinfo",
       "label": null,
       "selector": "body > footer"

--- a/test/test-landmarks.js
+++ b/test/test-landmarks.js
@@ -8,9 +8,103 @@ const testCodePath = path.join(__dirname, 'test-code-in-harness-landmarks.js')
 const fixturesDir = path.join(__dirname, 'fixtures')
 const dataDir = path.join(__dirname, 'data')
 
+const testSuiteFormatExample = {
+	'expected': [
+		{
+			'type': 'landmark',
+			'role': 'banner',
+			'label': null,
+			'selector': 'body > header',
+			'contains': [
+				{
+					'type': 'landmark',
+					'role': 'navigation',
+					'label': 'World of wombats',
+					'selector': 'body > header > nav'
+				}
+			]
+		},
+		{
+			'type': 'landmark',
+			'role': 'main',
+			'label': 'Looking after your wombat',
+			'selector': 'body > main',
+			'contains': [
+				{
+					'type': 'landmark',
+					'role': 'navigation',
+					'label': 'Looking after your wombat Topics',
+					'selector': 'body > main > nav:nth-child(2)'
+				}
+			]
+		},
+		{
+			'type': 'landmark',
+			'role': 'contentinfo',
+			'label': null,
+			'selector': 'body > footer'
+		}
+	]
+}
+
+const landmarksFormatExample = {
+	'expected': [
+		{
+			'depth': 0,
+			'role': 'banner',
+			'label': null,
+			'selector': 'body > header'
+		},
+		{
+			'depth': 1,
+			'role': 'navigation',
+			'label': 'World of wombats',
+			'selector': 'body > header > nav'
+		},
+		{
+			'depth': 0,
+			'role': 'main',
+			'label': 'Looking after your wombat',
+			'selector': 'body > main'
+		},
+		{
+			'depth': 1,
+			'role': 'navigation',
+			'label': 'Looking after your wombat Topics',
+			'selector': 'body > main > nav:nth-child(2)'
+		},
+		{
+			'depth': 0,
+			'role': 'contentinfo',
+			'label': null,
+			'selector': 'body > footer'
+		}
+	]
+}
+
 // Tiny helper functions
 const fixturePath = fileName => path.join(fixturesDir, fileName)
 const dataPath = fileName => path.join(dataDir, fileName)
+
+function convertCore(landmarksFormatData, testSuiteFormatData, depth) {
+	for (const landmark of testSuiteFormatData) {
+		landmarksFormatData.push({
+			'depth': depth,
+			'role': landmark.role,
+			'label': landmark.label,
+			'selector': landmark.selector
+		})
+		if (landmark.contains) {
+			convertCore(landmarksFormatData, landmark.contains, depth + 1)
+		}
+	}
+}
+
+function convertToLandmarksFormat(testSuiteFormatData) {
+	const landmarksFormatData = []
+	convertCore(landmarksFormatData, testSuiteFormatData, 0)
+	return landmarksFormatData
+}
 
 function createAllTests() {
 	const htmlFiles = fs.readdirSync(fixturesDir)
@@ -32,13 +126,20 @@ function createTest(testName, testFixture, testData) {
 		lf.find()
 		assert.deepEqual(
 			lf.allDepthsRolesLabelsSelectors(),
-			data.expected,
+			convertToLandmarksFormat(data.expected),
 			testName)
 	}
 }
 
 exports['test the damage report machine'] = function(assert) {
 	assert.ok(true, 'damage report machine intact')
+}
+
+exports['test conversion of Landmarks format results'] = function(assert) {
+	assert.deepEqual(
+		convertToLandmarksFormat(testSuiteFormatExample.expected),
+		landmarksFormatExample.expected,
+		'test data format conversion OK')
 }
 
 if (module === require.main) {


### PR DESCRIPTION
Allows Landmarks to keep its current code and data structure, but have the tests expressed as trees, which seems more natural for when the tests are factored out as a separate project.
