### PR TITLE
docs(Mozilla Add-ons): Update notes for reviewers

### DIFF
--- a/meta/amo-info-and-download.sh
+++ b/meta/amo-info-and-download.sh
@@ -1,15 +1,20 @@
 #!/bin/sh
 in='meta/amo-info.template'
 tag=$(git describe --tags --abbrev=0)
-changelog_line=$(grep $tag CHANGELOG.md)
-changelog_date=$(echo "$changelog_line" | egrep -o '\d{4}-\d{2}-\d{2}')
-tag_without_dots=$(echo $tag | tr -d .)
+changelog_line=$(grep "$tag" CHANGELOG.md)
+changelog_date=$(echo "$changelog_line" | grep -Eo '\d{4}-\d{2}-\d{2}')
+tag_without_dots=$(echo "$tag" | tr -d .)
 changelog_anchor="$tag_without_dots-$changelog_date"
 
-cat $in | sed \
+sed \
 	-e "s/CHANGELOG_ANCHOR/$changelog_anchor/g" \
-	-e "s/VERSION_NUMBER/$tag/g"
+	-e "s/VERSION_NUMBER/$tag/g" \
+	< $in
 
 echo
-github_code_url="https://github.com/matatk/landmarks/archive/$tag.zip"
-curl --remote-name --remote-header-name --location $github_code_url
+github_zip_file=$tag.zip
+github_code_url="https://github.com/matatk/landmarks/archive/$github_zip_file"
+curl \
+	--location "$github_code_url" \
+	--remote-name \
+	--remote-header-name

--- a/meta/amo-info.template
+++ b/meta/amo-info.template
@@ -8,7 +8,7 @@ The attached source is from the VERSION_NUMBER tag: <https://github.com/matatk/l
 
 Required software for the build:
 
-* git - needed to fetch my "one-svg-to-many-sized-pngs" node package from GitHub.
+* git - needed to fetch my "one-svg-to-many-sized-pngs" and "page-structural-semantics-scanner-tests" node packages from GitHub.
 * Node and npm.
 
 To build for Firefox specifically:


### PR DESCRIPTION
This updates the notes for building from source, for Mozilla reviewers.

Closes #322