### PR TITLE
fix: Clarify migration manager behaviour; Clean up tests and logging

### DIFF
--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -348,8 +348,8 @@ function runStartupCode() {
 }
 
 browser.storage.sync.get(null, function(items) {
-	const didMigration = migrationManager.migrate(items)
-	if (didMigration) {
+	const changedSettings = migrationManager.migrate(items)
+	if (changedSettings) {
 		browser.storage.sync.clear(function() {
 			browser.storage.sync.set(items, function() {
 				runStartupCode()

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -28,8 +28,6 @@ function restoreOptions() {
 			const name = option.name
 			const saved = items[name]
 
-			console.log('restoring', name, 'to', saved)
-
 			switch (option.kind) {
 				case 'radio':
 					document.getElementById(`radio-${saved}`).checked = true
@@ -48,7 +46,6 @@ function setUpOptionHandlers() {
 	for (const option of options) {
 		if (option.kind === 'individual') {
 			option.element.addEventListener('change', () => {
-				console.log('setting', option.name, 'to', option.element.value)
 				browser.storage.sync.set({
 					[option.name]: option.element.value
 				})
@@ -60,7 +57,6 @@ function setUpOptionHandlers() {
 		radio.addEventListener('change', function() {
 			const pref = this.parentElement.parentElement
 				.getAttribute('data-pref')
-			console.log('setting', pref, 'to', this.value)
 			browser.storage.sync.set({
 				[pref]: this.value
 			})

--- a/src/code/migrationManager.js
+++ b/src/code/migrationManager.js
@@ -8,10 +8,11 @@ export default function MigrationManager(migrations) {
 	}
 
 	function isMigrationNeeded(startingVersion) {
-		return startingVersion < Object.keys(migrations).pop()
+		return startingVersion < Number(Object.keys(migrations).pop())
 	}
 
 	this.migrate = function(settings) {
+		if (Object.keys(settings).length === 0) return false
 		const startingVersion = getVersion(settings)
 		if (isMigrationNeeded(startingVersion)) {
 			for (const key in migrations) {
@@ -21,7 +22,7 @@ export default function MigrationManager(migrations) {
 					settings.version = toVersion
 				}
 			}
-			console.log(`Landmarks: migrated settings from version ${startingVersion} to version ${settings.version}`)
+			console.log(`Landmarks: migrated user settings from version ${startingVersion} to version ${settings.version}`)
 			return true
 		}
 		return false

--- a/test/testContrastChecker.js
+++ b/test/testContrastChecker.js
@@ -4,10 +4,6 @@ const ContrastChecker = require('./generated-contrast-checker.js')
 
 const contrastChecker = new ContrastChecker()
 
-test('test the damage report machine', t => {
-	t.pass('damage report machine intact')
-})
-
 test('test white on black', t => {
 	t.is(
 		contrastChecker.contrastRatio('#ffffff', '#000000'),

--- a/test/testMigrationManager.js
+++ b/test/testMigrationManager.js
@@ -3,27 +3,60 @@
 const test = require('ava')
 const MigrationManager = require('./generated-migration-manager.js')
 
-test('test the damage report machine', t => {
-	t.pass('damage report machine intact')
-})
+// The purpose of the migration manager is to delete obsolete user settings, or
+// rename existing user settings to their current names. Landmarks ships with
+// current default settings, and code throughout the extension uses the
+// defaults if the setting hasn't been explicitly specified by the user.
+//
+// In the tests, though, it's easiest to use the addition of fields to indicate
+// whether migrations have occurred. In real life, new settings would be added
+// by amending the defaults file.
 
-test('test one field-adding migration (implied v0)', t => {
+test('skip migration if there are no user settings', t => {
 	const settings = {}
 	const migrations = {
 		1: function(settings) {
-			settings['newSetting'] = true
+			settings.something = 42
+		},
+		2: function(settings) {
+			settings.somethingElse = 'forty-two'
+		},
+		3: function(settings) {
+			settings.somethingCompletelyDifferent = 'for tea two'
 		}
 	}
 	const migrationManager = new MigrationManager(migrations)
-	migrationManager.migrate(settings)
-	t.is(settings.version, 1, 'bumped version')
-	t.is(settings.newSetting, true, 'added new setting')
+	const changed = migrationManager.migrate(settings)
+	t.is(changed, false, 'manager says settings were not changed')
+	t.deepEqual({}, settings, 'settings are still empty')
+
+	// We could set the latest version number in the user settings, which means
+	// that we could then skip going through _all_ the migrations if the user
+	// customises anything in future, but: (a) that would make the code more
+	// complex and (b) as migrations should be non-destructive, it doesn't
+	// matter if we go through outdated ones later.
 })
 
-test('test removing a field (explicit version number)', t => {
+test('renaming one field (implied v0)', t => {
+	const settings = { likedNumber: 42 }
+	const migrations = {
+		1: function(settings) {
+			if (settings.hasOwnProperty('likedNumber')) {
+				settings.favouriteNumber = settings.likedNumber
+				delete settings.likedNumber
+			}
+		}
+	}
+	const migrationManager = new MigrationManager(migrations)
+	const changed = migrationManager.migrate(settings)
+	t.is(changed, true, 'manager says settings were changed')
+	t.deepEqual({ favouriteNumber: 42, version: 1 }, settings)
+})
+
+test('removing one field (explicit version number)', t => {
 	const settings = {
-		'version': 42,
-		'deprecatedSetting': 'orange'
+		version: 42,
+		deprecatedSetting: 'orange'
 	}
 	const migrations = {
 		43: function(settings) {
@@ -31,14 +64,13 @@ test('test removing a field (explicit version number)', t => {
 		}
 	}
 	const migrationManager = new MigrationManager(migrations)
-	migrationManager.migrate(settings)
-	t.is(settings.version, 43, 'bumped version')
-	t.is(
-		settings.hasOwnProperty('deprecatedSetting'), false, 'removed setting')
+	const changed = migrationManager.migrate(settings)
+	t.is(changed, true, 'manager says settings were changed')
+	t.deepEqual({ version: 43 }, settings)
 })
 
-test('test two migrations (explicit v0)', t => {
-	const settings = { 'version': 0 }
+test('two migrations (explicit v0)', t => {
+	const settings = { version: 0 }
 	const migrations = {
 		1: function(settings) {
 			settings['newSetting'] = true
@@ -48,48 +80,30 @@ test('test two migrations (explicit v0)', t => {
 		}
 	}
 	const migrationManager = new MigrationManager(migrations)
-	migrationManager.migrate(settings)
-	t.is(settings.version, 2, 'got latest version')
-	t.is(settings.newSetting, true, 'added new setting')
-	t.is(settings.newNewSetting, true, 'added new new setting')
+	const changed = migrationManager.migrate(settings)
+	t.is(changed, true, 'manager says settings were changed')
+	t.deepEqual({
+		newSetting: true,
+		newNewSetting: true,
+		version: 2
+	}, settings)
 })
 
-test('test two migrations, only one needed, error path', t => {
-	// We're saying that we're starting with settings version 1, but we aren't.
-	const settings = { 'version': 1 }
-	const migrations = {
-		1: function(settings) {
-			settings['newSetting'] = true
-		},
-		2: function(settings) {
-			settings['newNewSetting'] = true
-		}
-	}
-	const migrationManager = new MigrationManager(migrations)
-	migrationManager.migrate(settings)
-	t.is(settings.version, 2, 'got latest version')
-	t.is(settings.newSetting, undefined, "didn't run migration 1")
-	t.is(settings.newNewSetting, true, 'added new new setting')
-})
-
-test('test returns false when migration not necessary', t => {
+test('two migrations, only one needed', t => {
 	const settings = { version: 1 }
 	const migrations = {
-		1: function() {
-			throw new Error('This should not be run')
+		1: function(settings) {
+			settings['newSetting'] = true
+		},
+		2: function(settings) {
+			settings['newNewSetting'] = true
 		}
 	}
 	const migrationManager = new MigrationManager(migrations)
-	const result = migrationManager.migrate(settings)
-	t.is(result, false, 'migration not needed')
-})
-
-test('test returns true when migration is necessary', t => {
-	const settings = {}
-	const migrations = {
-		1: function() {}
-	}
-	const migrationManager = new MigrationManager(migrations)
-	const result = migrationManager.migrate(settings)
-	t.is(result, true, 'migration was needed')
+	const changed = migrationManager.migrate(settings)
+	t.is(changed, true, 'manager says settings were changed')
+	t.deepEqual({
+		newNewSetting: true,
+		version: 2
+	}, settings)
 })


### PR DESCRIPTION
* Don't run migrations if there are no user settings. This requires that
  all migrations are non-destructive (renames will have to check for the
  field to rename). Current installations, where the code has set a
  'version' property in user settings, will still work.
* Remove redundant 'damage report machine' tests.
* Clarify existing migration manager tests.
* Remove console.log() calls from the options page code.