### PR TITLE
fix: Text colour in dark mode on Firefox

### DIFF
--- a/src/static/common.css
+++ b/src/static/common.css
@@ -94,7 +94,8 @@ input:hover {
 	outline-offset: var(--focus-outline-offset);
 }
 
-label {
+label,
+p {
 	color: var(--text-1);  /* countermand Firefox extension.css */
 }
 


### PR DESCRIPTION
Ensure warning/info text in the pop-up/sidebar is readable in dark mode.

Fixes #336