### PR TITLE
docs(Help): Clearer spacing around keyboard info

### DIFF
--- a/src/static/help.css
+++ b/src/static/help.css
@@ -32,3 +32,10 @@ td {
 
 td:last-child,
 .centre { text-align: center; }
+
+/* When there's no button to take the user to the browser's keyboard shortcut
+ * settings, leave a space between the end of the table and the manaul
+ * instructions. */
+#keyboard-shortcuts-table + details summary {
+	margin-top: 1em;
+}


### PR DESCRIPTION
In browsers where there is no button to take the user to the keyboard shortcut settings, increase the spacing between the end of the table and the start of the instructions, for clarity.

Fixes #335