### PR TITLE
fix: Text colour problem with previous dark-mode tweak

### DIFF
--- a/src/static/common.css
+++ b/src/static/common.css
@@ -94,11 +94,6 @@ input:hover {
 	outline-offset: var(--focus-outline-offset);
 }
 
-label,
-p {
-	color: var(--text-1);  /* countermand Firefox extension.css */
-}
-
 label:hover {
 	background-color: var(--light-accent-1);
 	outline: var(--standard-line);

--- a/src/static/common.gui.css
+++ b/src/static/common.gui.css
@@ -49,3 +49,8 @@ button {
 	margin-left: 0;
 	margin-right: var(--spacing);
 }
+
+label,
+p {
+	color: var(--text-1);  /* countermand Firefox extension.css */
+}


### PR DESCRIPTION
728e02d introduced a problem whereby the text in the "warning" messages on the help page were also affected. Moved both Firefox extension.css overrides to common.gui.css, as that is the proper place.