### PR TITLE
fix: Refine text colour fix to account for warnings

### DIFF
--- a/src/static/common.gui.css
+++ b/src/static/common.gui.css
@@ -51,6 +51,6 @@ button {
 }
 
 label,
-p {
+:not(.warning) > p {
 	color: var(--text-1);  /* countermand Firefox extension.css */
 }


### PR DESCRIPTION
40aed35 introduced an unforeseen consequence that the text in the
warning note in the sidebar was made light, thus very low-contrast,
which was not desired.

Oh my, perhaps I should really think about TDDing the UI somehow...