### PR TITLE
feat(DevTools): Much clearer UI and more accessible definitions

### DIFF
--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -22,6 +22,7 @@
 			</div>
 			<!-- /ui -->
 			<!-- devtools -->
+			<h1 data-message="extensionShortName"></h1>
 			<div id="connection-error" class="warning" hidden>
 				<p data-message="devToolsConnectionError"></p>
 			</div>
@@ -41,33 +42,62 @@
 
 		<div id="mutation-observation-station"> <!-- only in DevTools -->
 			<details>
-				<summary data-message="statsHeading"></summary>
+				<summary><h1 data-message="statsHeading"></h1></summary>
 				<dl>
-					<dt><details>
-						<summary data-message="statsMutationsTerm"></summary>
+					<dt id="statsMutationsTerm" data-message="statsMutationsTerm"></dt>
+					<dd>
+					<span id="mutations">0</span>
+					<details class="floaty">
+						<summary class="definition" aria-labelledby="define-statsMutationsTerm statsMutationsTerm">
+							<span id="define-statsMutationsTerm" data-message="statsDefine" class="visually-hidden"></span>
+						</summary>
 						<p data-message="statsMutationsDefinition"></p>
-					</details></dt>
-					<dd id="mutations">0</dd>
-					<dt><details>
-						<summary data-message="statsCheckedMutationsTerm"></summary>
+					</details>
+					</dd>
+
+					<dt id="statsCheckedMutationsTerm" data-message="statsCheckedMutationsTerm"></dt>
+					<dd>
+					<span id="checks">0</span>
+					<details class="floaty">
+						<summary class="definition" aria-labelledby="define-statsCheckedMutationsTerm statsCheckedMutationsTerm">
+							<span id="define-statsCheckedMutationsTerm" data-message="statsDefine" class="visually-hidden"></span>
+						</summary>
 						<p data-message="statsCheckedMutationsDefinition"></p>
-					</details></dt>
-					<dd id="checks">0</dd>
-					<dt><details>
-						<summary data-message="statsScansTerm"></summary>
+					</details>
+					</dd>
+
+					<dt id="statsScansTerm" data-message="statsScansTerm"></dt></dt>
+					<dd>
+					<span id="scans">0</span>
+					<details class="floaty">
+						<summary class="definition" aria-labelledby="define-statsScansTerm statsScansTerm">
+							<span id="define-statsScansTerm" data-message="statsDefine" class="visually-hidden"></span>
+						</summary>
 						<p data-message="statsScansDefinition"></p>
-					</details></dt>
-					<dd id="scans">0</dd>
-					<dt><details>
-						<summary data-message="statsPauseTerm"></summary>
+					</details>
+					</dd>
+
+					<dt id="statsPauseTerm" data-message="statsPauseTerm"></dt>
+					<dd>
+					<span id="pause">&mdash;</span>ms
+					<details class="floaty">
+						<summary class="definition" aria-labelledby="define-statsPauseTerm statsPauseTerm">
+							<span id="define-statsPauseTerm" data-message="statsDefine" class="visually-hidden"></span>
+						</summary>
 						<p data-message="statsPauseDefinition"></p>
-					</details></dt>
-					<dd id="pause">&mdash;</dd>
-					<dt><details>
-						<summary data-message="statsDurationTerm"></summary>
+					</details>
+					</dd>
+
+					<dt id="statsDurationTerm" data-message="statsDurationTerm"></dt>
+					<dd>
+					<span id="duration">&mdash;</span>ms
+					<details class="floaty">
+						<summary class="definition" aria-labelledby="define-statsDurationTerm statsDurationTerm">
+							<span id="define-statsDurationTerm" data-message="statsDefine" class="visually-hidden"></span>
+						</summary>
 						<p data-message="statsDurationDefinition"></p>
-					</details></dt>
-					<dd id="duration">&mdash;</dd>
+					</details>
+					</dd>
 				</dl>
 			</details>
 		</div>

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -256,5 +256,9 @@
 
   "statsDurationDefinition": {
     "message": "Number of milliseconds the last landmark scan took."
+  },
+
+  "statsDefine": {
+    "message": "Define"
   }
 }

--- a/src/static/common.css
+++ b/src/static/common.css
@@ -76,7 +76,8 @@ a {
 a:focus,
 a:hover,
 summary:focus,
-summary:hover {
+summary:hover,
+details[open] > summary {
 	color: var(--background-1);
 	background-color: var(--accent-1);
 	outline: var(--standard-line);
@@ -123,6 +124,22 @@ h2 {
 	width: 1px !important;
 	overflow: hidden;
 	white-space: nowrap;
+}
+
+/*
+ * Floating disclosure content is used in DevTools and the website
+ */
+
+details.floaty p {
+	position: absolute;
+	background-color: var(--accent-1);
+	outline: var(--standard-line);  /* to match that around the disclosure */
+	outline-color: var(--accent-1);
+	color: var(--background-1);
+	margin: 0;
+	margin-right: 1em;
+	max-width: 35em;
+	padding: 0.25em;
 }
 
 /*

--- a/src/static/devtoolsPanel.css
+++ b/src/static/devtoolsPanel.css
@@ -6,61 +6,39 @@ body {
 	height: 100%;
 }
 
-#content {
-	width: 100%;
-	flex-grow: 1;
-}
+#content { flex-grow: 1; }
 
 #mutation-observation-station {
-	border: 0;
-	border-top: var(--standard-control-line);
+	padding-left: 0.5rem;
+	padding-right: 0.5rem;
 }
 
-#mutation-observation-station > details > summary {
-	padding: 0.5em;
-	white-space: nowrap;
-}
-
-summary > h1 {
-	display: inline;
+h1 {
 	margin: 0;
+	font-size: 1rem;
 }
 
-/* Thanks to https://www.the-art-of-web.com/css/format-dl/ and https://stackoverflow.com/a/40762801/1485308 */
-dl {
-	margin: 0;
-	display: flex;
-	flex-wrap: wrap;
-	align-content: flex-start;
+summary > h1 { display: inline-block; }
+
+summary:hover > h1,
+details[open] summary h1 {
+	color: var(--background-1);
+	border-color: var(--background-1);
 }
 
-dt,
-dd {
-	margin: 0;
-	padding: 0.25em;
-	text-align: right;
-}
+details details { display: inline; }
+details details p { position: absolute; }
+summary.definition { list-style: none; }
+summary.definition::-webkit-details-marker { display: none; }
 
-dt {
-	width: calc(100% - 4em);
-}
-
-details > p {
-	text-align: left;
-	margin: 0;
-	padding: 0.25em;
-	max-width: 15em;
-	float: right;
-	color: var(--text-2);
+summary.definition::after {
+	content: "?";
+	border: var(--standard-control-line);
+	margin: var(--top-padding);
+	padding-left: var(--top-padding);
+	padding-right: var(--top-padding);
 }
 
 @media screen and (orientation: landscape) {
-	body {
-		flex-direction: row;
-	}
-
-	#mutation-observation-station {
-		border: 0;
-		border-left: var(--standard-control-line);
-	}
+	body { flex-direction: row; }
 }


### PR DESCRIPTION
* Improve the visual formatting in the DevTools panel.
* Massively improve the structure of the mutation observation station.
  The definitions are accessible from the values, not the terms, and
  they are labelled accessibly, but take up little visual space.
* Base some of this on the styles used on the web page (gh-pages will
  need to be updated accordingly).