### PR TITLE
fix: Floating disclosure widget style

### DIFF
--- a/src/static/common.css
+++ b/src/static/common.css
@@ -130,16 +130,19 @@ h2 {
  * Floating disclosure content is used in DevTools and the website
  */
 
-details.floaty p {
+details.floaty > p,
+details.floaty > div {
 	position: absolute;
 	background-color: var(--accent-1);
 	outline: var(--standard-line);  /* to match that around the disclosure */
 	outline-color: var(--accent-1);
 	color: var(--background-1);
-	margin: 0;
-	margin-right: 1em;
 	max-width: 35em;
-	padding: 0.25em;
+	margin-top: 0;
+	margin-right: 1em;
+	padding-left: 0.5em;
+	padding-right: 0.5em;
+	z-index: 1;
 }
 
 /*


### PR DESCRIPTION
Make some tweaks to improve this both in the extension and in the web page, which inherits common.css from the extension.

This change makes the 'floating' nature work with disclosures that directly contain a paragraph, or a `<div>` that can contain other stuff.