### PR TITLE
build(Test versions): Simplify test versions

### DIFF
--- a/meta/test-version-description
+++ b/meta/test-version-description
@@ -1,0 +1,5 @@
+This is the test version of the Landmarks extension.
+
+Please do not use this version unless you are helping out with a particular issue.
+
+You can find the stable version at: http://matatk.agrip.org.uk/landmarks/

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -86,8 +86,6 @@ let testMode = false	// are we building a test (alpha/beta) version?
 // Utilities
 //
 
-const exampleTestRelease = "'2.1.0alpha1'"
-
 function doReplace(files, from, to, message) {
 	try {
 		const results = replace.sync({
@@ -542,7 +540,7 @@ async function main() {
 		.describe('browser', 'Build for a specific browser, or all browsers. Existing build directory and extension ZIP files are deleted first.')
 		.choices('browser', buildTargets)
 		.alias('browser', 'b')
-		.describe('test-release', `Build an experimental release (Chrome-only: a Firefox test release such as ${exampleTestRelease} can be uploaded to the add-on's beta channel).`)
+		.describe('test-release', 'Build an experimental release, which is falgged as being a test version')
 		.boolean('test-release')
 		.alias('test-release', 't')
 		.describe('release', 'Override release in manifest.json. This should only be used when making test releases.')
@@ -575,9 +573,6 @@ async function main() {
 	const debugMode = argv.debug === true
 
 	testMode = argv.testRelease === true
-	if (testMode && argv.browser !== 'chrome') {
-		error(`Test build requested for browser(s) other than Chrome. This is not advisable: e.g. for Firefox, a version number such as ${exampleTestRelease} can be set instead and the extension uploaded to the beta channel. Only Chrome needs a separate extension listing for test versions.`)
-	}
 	const testModeMessage = testMode ? ' (test version)' : ''
 
 	for (const browser of browsers) {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -20,7 +20,7 @@ const dependencyTree = require('dependency-tree')
 
 const packageJson = require(path.join('..', 'package.json'))
 const extName = packageJson.name
-const extVersion = packageJson.version
+let extVersion = packageJson.version  // can be overidden on command line
 const buildDir = 'build'
 const srcStaticDir = path.join('src', 'static')
 const srcAssembleDir = path.join('src', 'assemble')
@@ -85,6 +85,8 @@ let testMode = false	// are we building a test (alpha/beta) version?
 //
 // Utilities
 //
+
+const exampleTestRelease = "'2.1.0alpha1'"
 
 function doReplace(files, from, to, message) {
 	try {
@@ -540,9 +542,13 @@ async function main() {
 		.describe('browser', 'Build for a specific browser, or all browsers. Existing build directory and extension ZIP files are deleted first.')
 		.choices('browser', buildTargets)
 		.alias('browser', 'b')
-		.describe('test-release', "Build an experimental release (Chrome-only: a Firefox test release can be uploaded to the add-on's beta channel).")
+		.describe('test-release', `Build an experimental release (Chrome-only: a Firefox test release such as ${exampleTestRelease} can be uploaded to the add-on's beta channel).`)
 		.boolean('test-release')
 		.alias('test-release', 't')
+		.describe('release', 'Override release in manifest.json. This should only be used when making test releases.')
+		.string('release')
+		.nargs('release', 1)
+		.alias('release', 'r')
 		.describe('clean-only', "Don't build; just remove existing build directory and ZIP.")
 		.boolean('clean-only')
 		.alias('clean-only', 'c')
@@ -554,6 +560,8 @@ async function main() {
 		.alias('skip-linting', 'k')
 		.demandOption('browser')
 		.argv
+
+	if (argv.release) extVersion = argv.release
 
 	const browsers = argv.browser === 'all'
 		? validBrowsers
@@ -568,7 +576,7 @@ async function main() {
 
 	testMode = argv.testRelease === true
 	if (testMode && argv.browser !== 'chrome') {
-		error("Test build requested for browser(s) other than Chrome. This is not advisable: e.g. for Firefox, a version number such as '2.1.0alpha1' can be set instead and the extension uploaded to the beta channel. Only Chrome needs a separate extension listing for test versions.")
+		error(`Test build requested for browser(s) other than Chrome. This is not advisable: e.g. for Firefox, a version number such as ${exampleTestRelease} can be set instead and the extension uploaded to the beta channel. Only Chrome needs a separate extension listing for test versions.`)
 	}
 	const testModeMessage = testMode ? ' (test version)' : ''
 


### PR DESCRIPTION
* Allow making a test version for all browsers (AMO no longer supports a beta channel).
* Include a description that can be used for the test versions (nobody should stumble on this; you can still have an unlisted extension in Chrome).
* Allow specifying a custom release number on the command-line.