### PR TITLE
feat: Softer update notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,15 @@
       "!test/generated-*.js",
       "!test/rollup.config.js"
     ],
-    "require": ["esm"]
+    "require": [
+      "esm"
+    ]
   },
-  "nyc": { "require": ["esm"] },
+  "nyc": {
+    "require": [
+      "esm"
+    ]
+  },
   "devDependencies": {
     "addons-linter": "^2.1.0",
     "archiver-promise": "~1.0",

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -18,13 +18,13 @@
 			<div id="note-ui" class="warning" hidden>
 				<p data-message="hintSidebarIsNotPrimary"></p>
 				<button id="note-ui-cta" data-message="hintSidebarIsNotPrimaryCTA"></button>
-				<button id="note-ui-dismiss" data-message="hintDismiss"></button>
+				<button id="note-ui-dismiss" data-message="hintSidebarIsNotPrimaryDismiss"></button>
 			</div>
 			<!-- /ui -->
 			<div id="note-update" class="warning" hidden>
 				<p><span data-message="hintWhatIsNew"></span> <span id="version"></span>.</p>
 				<button id="note-update-cta" data-message="hintWhatIsNewCTA"></button>
-				<button id="note-update-dismiss" data-message="hintDismiss"></button>
+				<button id="note-update-dismiss" data-message="hintWhatIsNewDismiss"></button>
 			</div>
 			<!-- devtools -->
 			<h1 data-message="extensionShortName"></h1>

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -22,8 +22,8 @@
 			</div>
 			<!-- /ui -->
 			<div id="note-update" class="warning" hidden>
-				<p>There has been an update!</p>
-				<button id="note-update-cta">Help/update info</button>
+				<p>Landmarks was updated to version <span id="version"></span>.</p>
+				<button id="note-update-cta">What's new?</button>
 				<button id="note-update-dismiss" data-message="hintDismiss"></button>
 			</div>
 			<!-- devtools -->

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -21,6 +21,11 @@
 				<button id="note-dismiss" data-message="hintDismiss"></button>
 			</div>
 			<!-- /ui -->
+			<div id="note2" class="warning">
+				<p>Update</p>
+				<button id="note2-update">hello</button>
+				<button id="note2-dismiss" data-message="hintDismiss"></button>
+			</div>
 			<!-- devtools -->
 			<h1 data-message="extensionShortName"></h1>
 			<div id="connection-error" class="warning" hidden>

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -15,16 +15,16 @@
 	<body>
 		<div id="content">
 			<!-- ui -->
-			<div id="note" class="warning" hidden>
+			<div id="note-ui" class="warning" hidden>
 				<p>Landmarks is set up to use a pop-up. The sidebar will still work, but using the shortcut key will make the pop-up appear, not the sidebar.</p>
-				<button id="note-prefs" data-message="hintSidebarIsNotPrimaryOptions"></button>
-				<button id="note-dismiss" data-message="hintDismiss"></button>
+				<button id="note-ui-cta" data-message="hintSidebarIsNotPrimaryOptions"></button>
+				<button id="note-ui-dismiss" data-message="hintDismiss"></button>
 			</div>
 			<!-- /ui -->
-			<div id="note2" class="warning">
-				<p>Update</p>
-				<button id="note2-update">hello</button>
-				<button id="note2-dismiss" data-message="hintDismiss"></button>
+			<div id="note-update" class="warning" hidden>
+				<p>There has been an update!</p>
+				<button id="note-update-cta">Help/update info</button>
+				<button id="note-update-dismiss" data-message="hintDismiss"></button>
 			</div>
 			<!-- devtools -->
 			<h1 data-message="extensionShortName"></h1>

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -11,7 +11,7 @@
 		<!-- devtools -->
 		<link rel="stylesheet" href="devtoolsPanel.css">
 		<!-- /devtools -->
-	</head>  <!-- FIXME: this gets aligned wrongly after the replace -->
+	</head>  <!-- TODO: this gets aligned wrongly after the replace -->
 	<body>
 		<div id="content">
 			<!-- ui -->

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -16,14 +16,14 @@
 		<div id="content">
 			<!-- ui -->
 			<div id="note-ui" class="warning" hidden>
-				<p>Landmarks is set up to use a pop-up. The sidebar will still work, but using the shortcut key will make the pop-up appear, not the sidebar.</p>
-				<button id="note-ui-cta" data-message="hintSidebarIsNotPrimaryOptions"></button>
+				<p data-message="hintSidebarIsNotPrimary"></p>
+				<button id="note-ui-cta" data-message="hintSidebarIsNotPrimaryCTA"></button>
 				<button id="note-ui-dismiss" data-message="hintDismiss"></button>
 			</div>
 			<!-- /ui -->
 			<div id="note-update" class="warning" hidden>
-				<p>Landmarks was updated to version <span id="version"></span>.</p>
-				<button id="note-update-cta">What's new?</button>
+				<p><span data-message="hintWhatIsNew"></span> <span id="version"></span>.</p>
+				<button id="note-update-cta" data-message="hintWhatIsNewCTA"></button>
 				<button id="note-update-dismiss" data-message="hintDismiss"></button>
 			</div>
 			<!-- devtools -->

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -260,5 +260,20 @@
 
   "statsDefine": {
     "message": "Define"
+  },
+
+
+
+
+  "hintDismiss": {
+    "message": "Dismiss note"
+  },
+
+  "hintWhatIsNew": {
+    "message": "Landmarks was updated to version"
+  },
+
+  "hintWhatIsNewCTA": {
+    "message": "What's new?"
   }
 }

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -277,16 +277,16 @@
 
 
 
-  "hintDismiss": {
-    "message": "Dismiss note"
-  },
-
   "hintWhatIsNew": {
     "message": "Landmarks was updated to version"
   },
 
   "hintWhatIsNewCTA": {
     "message": "What's new?"
+  },
+
+  "hintWhatIsNewDismiss": {
+    "message": "Dismiss update note"
   },
 
 

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -92,6 +92,18 @@
     "message": "Reset settings to defaults"
   },
 
+  "prefsResetMessages": {
+    "message": "Reinstate dismissed messages"
+  },
+
+  "prefsResetMessagesNone": {
+    "message": "No messages to reinstate."
+  },
+
+  "prefsResetMessagesDone": {
+    "message": "Help messages have been reinstated."
+  },
+
 
 
 

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -275,5 +275,12 @@
 
   "hintWhatIsNewCTA": {
     "message": "What's new?"
+  },
+
+
+
+
+  "badgeNew": {
+    "message": "NEW"
   }
 }

--- a/src/assemble/messages.interface.en_GB.json
+++ b/src/assemble/messages.interface.en_GB.json
@@ -19,18 +19,6 @@
     "message": "Landmarks will be shown in the sidebar, which can be opened via the toolbar button or shortcut key."
   },
 
-  "prefsResetMessages": {
-    "message": "Reinstate dismissed messages"
-  },
-
-  "prefsResetMessagesNone": {
-    "message": "No messages to reinstate."
-  },
-
-  "prefsResetMessagesDone": {
-    "message": "Help messages have been reinstated."
-  },
-
 
 
 

--- a/src/assemble/messages.interface.en_GB.json
+++ b/src/assemble/messages.interface.en_GB.json
@@ -33,15 +33,12 @@
 
 
 
+
   "hintSidebarIsNotPrimary": {
     "message": "Landmarks is set up to use a pop-up. The sidebar will still work, but using the shortcut key will make the pop-up appear, not the sidebar."
   },
 
-  "hintSidebarIsNotPrimaryOptions": {
+  "hintSidebarIsNotPrimaryCTA": {
     "message": "Change preferences"
-  },
-
-  "hintDismiss": {
-    "message": "Dismiss note"
   }
 }

--- a/src/assemble/messages.interface.en_GB.json
+++ b/src/assemble/messages.interface.en_GB.json
@@ -28,5 +28,9 @@
 
   "hintSidebarIsNotPrimaryCTA": {
     "message": "Change preferences"
+  },
+
+  "hintSidebarIsNotPrimaryDismiss": {
+    "message": "Dismiss UI note"
   }
 }

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -247,7 +247,8 @@ function reflectUpdateDismissalState(dismissed, doNotBadge) {
 			updateGUIs(tabs[0].id, tabs[0].url)
 		})
 	} else if (!doNotBadge) {
-		browser.browserAction.setBadgeText({ text: 'NEW' })  // FIXME l10n
+		browser.browserAction.setBadgeText(
+			{ text: browser.i18n.getMessage('badgeNew') })
 	}
 }
 

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -109,11 +109,12 @@ function sendDevToolsStateMessage(tabId, panelIsOpen) {
 // will receive events, which we can then use to open the sidebar.
 //
 // Opera doesn't have open().
+//
+// These things are only referenced from within browser-conditional blocks, so
+// Terser removes them as appropriate.
 
-// TODO check this gets terser'd out
 const sidebarToggle = () => browser.sidebarAction.toggle()
 
-// TODO check this gets terser'd out
 function switchInterface(mode) {
 	switch (mode) {
 		case 'sidebar':

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -261,7 +261,7 @@ startupCode.push(function() {
 browser.runtime.onInstalled.addListener(function(details) {
 	if (details.reason === 'install') {
 		browser.tabs.create({ url: 'help.html#!install' })
-		browser.storage.sync.set({ dismissedUpdate: true })
+		browser.storage.sync.set({ 'dismissedUpdate': true })
 	}
 })
 
@@ -287,7 +287,7 @@ function openHelpPage(openInSameTab) {
 		})
 	}
 	if (!dismissedUpdate) {
-		browser.storage.sync.set({ dismissedUpdate: true })
+		browser.storage.sync.set({ 'dismissedUpdate': true })
 	}
 }
 

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -371,12 +371,7 @@ browser.storage.onChanged.addListener(function(changes) {
 	}
 
 	if (changes.hasOwnProperty('dismissedUpdate')) {
-		// If the user later resets dismissed messages, we don't want to start
-		// badging the browserAction again. The note will still be shown in the
-		// GUI by separate means.
-		if (changes.dismissedUpdate.newValue === true) {
-			reflectUpdateDismissalState(true)
-		}
+		reflectUpdateDismissalState(changes.dismissedUpdate.newValue)
 	}
 })
 

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -240,6 +240,7 @@ browser.tabs.onActivated.addListener(function(activeTabInfo) {
 function reflectUpdateDismissalState(dismissed) {
 	dismissedUpdate = dismissed
 	if (dismissedUpdate) {
+		browser.browserAction.setBadgeText({ text: '' })
 		browser.tabs.query({ active: true, currentWindow: true }, tabs => {
 			updateGUIs(tabs[0].id, tabs[0].url)
 		})
@@ -370,7 +371,12 @@ browser.storage.onChanged.addListener(function(changes) {
 	}
 
 	if (changes.hasOwnProperty('dismissedUpdate')) {
-		reflectUpdateDismissalState(changes.dismissedUpdate.newValue)
+		// If the user later resets dismissed messages, we don't want to start
+		// badging the browserAction again. The note will still be shown in the
+		// GUI by separate means.
+		if (changes.dismissedUpdate.newValue === true) {
+			reflectUpdateDismissalState(true)
+		}
 	}
 })
 

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -245,7 +245,7 @@ browser.tabs.onActivated.addListener(function(activeTabInfo) {
 
 function reflectUpdateAcknowledgement() {
 	if (!dismissedUpdate) {
-		browser.browserAction.setBadgeText({ text: 'NEW' })
+		browser.browserAction.setBadgeText({ text: 'NEW' })  // FIXME l10n
 	}
 }
 

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -284,7 +284,9 @@ function openHelpPage(openInSameTab) {
 			})
 		})
 	}
-	browser.storage.sync.set({ updateAcknowledged: true })
+	if (!updateAcknowledged) {
+		browser.storage.sync.set({ updateAcknowledged: true })
+	}
 }
 
 browser.runtime.onMessage.addListener(function(message, sender) {

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -326,6 +326,7 @@ function handleMutationMessage(data) {
 //       shouldn't really have it, but at least it keeps all the code here,
 //       rather than putting some separately in the build script.
 function startupDevTools() {
+	document.getElementById('note-update').remove()
 	document.getElementById('links').remove()
 
 	port = browser.runtime.connect({ name: INTERFACE })
@@ -379,6 +380,11 @@ function startupPopupOrSidebar() {
 			browser.tabs.sendMessage(tab.id, { name: 'get-toggle-state' })
 		})
 	})
+
+	document.getElementById('version').innerText =
+		browser.runtime.getManifest().version
+
+	setupNotes()
 }
 
 function main() {
@@ -387,8 +393,6 @@ function main() {
 	} else {
 		startupPopupOrSidebar()
 	}
-
-	setupNotes()
 
 	document.getElementById('show-all').addEventListener('change', function() {
 		send({ name: 'toggle-all-landmarks' })

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -3,7 +3,7 @@
 import './compatibility'
 import translate from './translate'
 import landmarkName from './landmarkName'
-import { defaultInterfaceSettings, dismissalStates } from './defaults'
+import { defaultInterfaceSettings, defaultDismissalStates } from './defaults'
 import { isContentScriptablePage } from './isContent'
 
 let port = null
@@ -152,7 +152,7 @@ if (INTERFACE === 'sidebar') {
 	// sidebar to explain this to the user.
 
 	function showNote() {  // eslint-disable-line no-inner-declarations
-		browser.storage.sync.get(dismissalStates, function(items) {
+		browser.storage.sync.get(defaultDismissalStates, function(items) {
 			if (items.dismissedSidebarNotAlone === false) {
 				document.getElementById('note').hidden = false
 			}

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -29,7 +29,9 @@ const _updateNote = {
 	'dismissedUpdate': {
 		id: 'note-update',
 		cta: function() {
+			// FIXME DRY
 			browser.runtime.sendMessage({ name: 'open-help' })
+			if (INTERFACE === 'popup') window.close()
 		}
 	}
 }

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -29,7 +29,7 @@ const _updateNote = {
 	'dismissedUpdate': {
 		id: 'note-update',
 		cta: function() {
-			alert('update note thing activated')
+			browser.runtime.sendMessage({ name: 'open-help' })
 		}
 	}
 }

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -229,7 +229,6 @@ function setupNotes() {
 	}
 
 	browser.storage.onChanged.addListener(function(changes) {
-		// TODO this probably leaves an anonymous code block too
 		if (INTERFACE === 'sidebar') {
 			if (changes.hasOwnProperty('interface')) {
 				reflectInterfaceChange(changes.interface.newValue)

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -320,12 +320,11 @@ function handleMutationMessage(data) {
 // Start-up
 //
 
-// TODO check wording:
 // Note: Firefox doesn't use 'devToolsConnectionError' but if it is not
 //       mentioned here, the build will not pass the unused messages check.
-//       This is a bit hacky, as these browsers really aren't using it, so
-//       shouldn't really have it, but at least it keeps all the code here,
-//       rather than putting some separately in the build script.
+//       Keeping it in the GUI HTML but hiding it is hacky, as the browser
+//       really isn't using it, but at least it keeps all the code here, rather
+//       than putting some separately in the build script.
 function startupDevTools() {
 	document.getElementById('note-update').remove()
 	document.getElementById('links').remove()

--- a/src/code/_help.js
+++ b/src/code/_help.js
@@ -15,9 +15,8 @@ function messageHandler(message) {
 }
 
 function includeVersionNumber() {
-	const manifest = browser.runtime.getManifest()
-	const version = manifest.version
-	document.getElementById('version').innerText = version
+	document.getElementById('version').innerText =
+		browser.runtime.getManifest().version
 }
 
 function reflectInstallOrUpdate() {

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-prototype-builtins */
 import './compatibility'
 import translate from './translate'
-import { defaultSettings, dismissalStates } from './defaults'
+import { defaultSettings, defaultDismissalStates } from './defaults'
 
 
 //
@@ -74,7 +74,7 @@ function updateResetDismissedMessagesButtonState() {
 	const button = document.getElementById('reset-messages')
 	const feedback = document.getElementById('reset-messages-feedback')
 
-	browser.storage.sync.get(dismissalStates, function(items) {
+	browser.storage.sync.get(defaultDismissalStates, function(items) {
 		for (const dismissalState in items) {
 			if (items[dismissalState] === true) {
 				button.dataset.someMessagesDismissed = true
@@ -93,14 +93,14 @@ function updateResetDismissedMessagesButtonState() {
 
 function resetMessages() {
 	if (this.dataset.someMessagesDismissed === String(true)) {
-		browser.storage.sync.set(dismissalStates)  // default values are false
+		browser.storage.sync.set(defaultDismissalStates)
 		document.getElementById('reset-messages-feedback')
 			.innerText = browser.i18n.getMessage('prefsResetMessagesDone')
 	}
 }
 
 function dismissalStateChanged(thingChanged) {
-	return dismissalStates.hasOwnProperty(thingChanged)
+	return defaultDismissalStates.hasOwnProperty(thingChanged)
 }
 
 function resetToDefaults() {

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -63,10 +63,7 @@ function setUpOptionHandlers() {
 		})
 	}
 
-	if (BROWSER === 'firefox' || BROWSER === 'opera') {
-		document.getElementById('reset-messages').onclick = resetMessages
-	}
-
+	document.getElementById('reset-messages').onclick = resetMessages
 	document.getElementById('reset-to-defaults').onclick = resetToDefaults
 }
 
@@ -124,15 +121,15 @@ function main() {
 			name: 'interface',
 			kind: 'radio'
 		})
-
-		updateResetDismissedMessagesButtonState()
-
-		browser.storage.onChanged.addListener(function(changes) {
-			if (Object.keys(changes).some(dismissalStateChanged)) {
-				updateResetDismissedMessagesButtonState()
-			}
-		})
 	}
+
+	updateResetDismissedMessagesButtonState()
+
+	browser.storage.onChanged.addListener(function(changes) {
+		if (Object.keys(changes).some(dismissalStateChanged)) {
+			updateResetDismissedMessagesButtonState()
+		}
+	})
 
 	translate()
 	restoreOptions()

--- a/src/code/defaults.js
+++ b/src/code/defaults.js
@@ -25,16 +25,15 @@ export const defaultSettings =
 // Dismissal state of user interface messages
 //
 
-export const dismissalStates =
+const defaultDismissedSidebarNotAlone = Object.freeze(
+	{ dismissedSidebarNotAlone: false })
+
+export const defaultDismissedUpdate = Object.freeze(
+	{ dismissedUpdate: false })
+
+export const defaultDismissalStates =
 	(BROWSER === 'firefox' || BROWSER === 'opera')
-		? Object.freeze({ dismissedSidebarNotAlone: false })
-		: null
-
-
-//
-// Update acknowledgement
-//
-
-export const defaultUpdateAcknowledged = Object.freeze({
-	updateAcknowledged: false
-})
+		? Object.freeze(Object.assign({},
+			defaultDismissedSidebarNotAlone,
+			defaultDismissedUpdate))
+		: defaultDismissedUpdate

--- a/src/code/defaults.js
+++ b/src/code/defaults.js
@@ -29,3 +29,12 @@ export const dismissalStates =
 	(BROWSER === 'firefox' || BROWSER === 'opera')
 		? Object.freeze({ dismissedSidebarNotAlone: false })
 		: null
+
+
+//
+// Update acknowledgement
+//
+
+export const defaultUpdateAcknowledged = Object.freeze({
+	updateAcknowledged: false
+})

--- a/src/code/defaults.js
+++ b/src/code/defaults.js
@@ -25,7 +25,7 @@ export const defaultSettings =
 // Dismissal state of user interface messages
 //
 
-const defaultDismissedSidebarNotAlone = Object.freeze(
+export const defaultDismissedSidebarNotAlone = Object.freeze(
 	{ dismissedSidebarNotAlone: false })
 
 export const defaultDismissedUpdate = Object.freeze(

--- a/src/static/common.css
+++ b/src/static/common.css
@@ -5,6 +5,7 @@
 	--accent-1: #080;
 	--light-accent-1: #0805;
 	--accent-2: #ff6200;
+	--accent-3: #ff2f92;
 	--background-1: white;
 	--background-2: #ccc;
 	--text-1: #333;
@@ -35,6 +36,7 @@
 		--accent-1: #9f9;
 		--light-accent-1: #9f95;
 		--accent-2: #fa6;
+		--accent-3: #ff6eb3;
 		--background-1: #272727;
 		--background-2: #555;
 		--text-1: #ddd;
@@ -111,7 +113,7 @@ html {
 
 h1,
 h2 {
-	border-bottom: var(--standard-line);
+	border-bottom: var(--thickness) solid var(--accent-1);
 	color: var(--accent-1);
 }
 
@@ -164,6 +166,11 @@ details.floaty > div {
 	align-items: center;
 }
 
+.warning + .warning {
+	margin-top: var(--sibling-gap);
+	background-color: var(--accent-3);
+}
+
 .warning > .warning-symbol {
 	font-size: 2rem;
 	font-weight: bold;
@@ -184,4 +191,12 @@ details.floaty > div {
 .warning a:focus,
 .warning a:hover {
 	outline-color: var(--background-1);
+}
+
+.warning + .warning a:focus,
+.warning + .warning a:hover,
+.warning + .warning button:focus,
+.warning + .warning button:hover {
+	background-color: var(--background-1);
+	color: var(--accent-3);
 }

--- a/src/static/common.gui.css
+++ b/src/static/common.gui.css
@@ -14,6 +14,12 @@ button {
 	text-align: center;  /* needed for Firefox due to using browser styles */
 }
 
+/*
+ * Warning boxes - building on common.css
+ *
+ * These warnings are designed to have a paragraph followed by two buttons
+ */
+
 .warning {
 	/* The note is displayed as flexbox due to the general "warning" class, but
 	 * we want to display it vertically in the sidebar */

--- a/src/static/common.gui.css
+++ b/src/static/common.gui.css
@@ -7,7 +7,32 @@ body { margin: 0; }
 	padding-top: 0;
 }
 
-.warning { margin-top: var(--spacing); }
+button {
+	/* Due to using browser styles, we need to override height in Firefox
+	 * https://github.com/matatk/landmarks/issues/149 */
+	height: auto;
+	text-align: center;  /* needed for Firefox due to using browser styles */
+}
+
+.warning {
+	/* The note is displayed as flexbox due to the general "warning" class, but
+	 * we want to display it vertically in the sidebar */
+	flex-direction: column;
+	margin-bottom: calc(var(--spacing) * 2);
+	margin-top: var(--spacing);
+}
+
+.warning > :first-child { margin-top: calc(var(--spacing) * 2); }
+.warning > * { margin-bottom: calc(var(--spacing) * 2); }
+.warning > :last-child { margin-left: 0; }  /* countermand common.css */
+
+.warning button {
+	width: 100%;
+	border-color: var(--background-1);
+	color: var(--background-1);
+	background-color: var(--accent-2);
+	font-weight: bold;
+}
 
 ul {
 	margin: 0;
@@ -19,13 +44,6 @@ ul ul { padding-left: 2rem; }
 li {
 	display: block;
 	margin-top: 0.5rem;
-}
-
-button {
-	/* Due to using browser styles, we need to override height in Firefox
-	 * https://github.com/matatk/landmarks/issues/149 */
-	height: auto;
-	text-align: center;  /* needed for Firefox due to using browser styles */
 }
 
 #show-all-label {

--- a/src/static/common.gui.css
+++ b/src/static/common.gui.css
@@ -40,6 +40,10 @@ button {
 	font-weight: bold;
 }
 
+.warning + .warning button {
+	background-color: var(--accent-3);
+}
+
 ul {
 	margin: 0;
 	padding: 0;

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -63,12 +63,10 @@
 				<input type="number" id="border-font-size" data-pref="borderFontSize">
 			</div>
 
-			<!-- ui -->
 			<div>
 				<button id="reset-messages" data-message="prefsResetMessages" aria-describedby="reset-messages-feedback"></button>
 				<span aria-live="polite" id="reset-messages-feedback"></span>
 			</div>
-			<!-- /ui -->
 
 			<button id="reset-to-defaults" data-message="prefsResetAll"></button>
 		</main>

--- a/src/static/sidebar.css
+++ b/src/static/sidebar.css
@@ -7,22 +7,3 @@ body {
 }
 
 #content { flex-grow: 1; }
-
-.warning {
-	/* The note is displayed as flexbox due to the general "warning" class, but
-	 * we want to display it vertically in the sidebar */
-	flex-direction: column;
-	margin-bottom: 0.5rem;
-}
-
-.warning > :first-child { margin-top: 0.5rem; }
-.warning > * { margin-bottom: 0.5rem; }
-.warning > :last-child { margin-left: 0; }  /* countermand common.css */
-
-.warning button {
-	width: 100%;
-	border-color: var(--background-1);
-	color: var(--background-1);
-	background-color: var(--accent-2);
-	font-weight: bold;
-}


### PR DESCRIPTION
Instead of opening the help page as soon as an update has been installed, put a badge on the toolbar button, and a notice in the pop-up and sidebar, which can be dismissed.

This results in some code that was previously only used on Firefox and Opera being shared across all browsers.

Landmarks will still open its help page on installation.

Fixes #310