### PR TITLE
feat: Move DevTools UI to the DOM Inspector panel

### DIFF
--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -46,11 +46,10 @@
 		</div>
 
 		<div id="mutation-observation-station"> <!-- only in DevTools -->
-			<details>
-				<summary><h1 data-message="statsHeading"></h1></summary>
-				<dl>
-					<dt id="statsMutationsTerm" data-message="statsMutationsTerm"></dt>
-					<dd>
+			<h1 data-message="statsHeading"></h1>
+			<dl>
+				<dt id="statsMutationsTerm" data-message="statsMutationsTerm"></dt>
+				<dd>
 					<span id="mutations">0</span>
 					<details class="floaty">
 						<summary class="definition" aria-labelledby="define-statsMutationsTerm statsMutationsTerm">
@@ -58,10 +57,10 @@
 						</summary>
 						<p data-message="statsMutationsDefinition"></p>
 					</details>
-					</dd>
+				</dd>
 
-					<dt id="statsCheckedMutationsTerm" data-message="statsCheckedMutationsTerm"></dt>
-					<dd>
+				<dt id="statsCheckedMutationsTerm" data-message="statsCheckedMutationsTerm"></dt>
+				<dd>
 					<span id="checks">0</span>
 					<details class="floaty">
 						<summary class="definition" aria-labelledby="define-statsCheckedMutationsTerm statsCheckedMutationsTerm">
@@ -69,42 +68,41 @@
 						</summary>
 						<p data-message="statsCheckedMutationsDefinition"></p>
 					</details>
-					</dd>
+				</dd>
 
-					<dt id="statsScansTerm" data-message="statsScansTerm"></dt></dt>
-					<dd>
-					<span id="scans">0</span>
-					<details class="floaty">
-						<summary class="definition" aria-labelledby="define-statsScansTerm statsScansTerm">
-							<span id="define-statsScansTerm" data-message="statsDefine" class="visually-hidden"></span>
-						</summary>
-						<p data-message="statsScansDefinition"></p>
-					</details>
-					</dd>
+				<dt id="statsScansTerm" data-message="statsScansTerm"></dt></dt>
+			<dd>
+				<span id="scans">0</span>
+				<details class="floaty">
+					<summary class="definition" aria-labelledby="define-statsScansTerm statsScansTerm">
+						<span id="define-statsScansTerm" data-message="statsDefine" class="visually-hidden"></span>
+					</summary>
+					<p data-message="statsScansDefinition"></p>
+				</details>
+			</dd>
 
-					<dt id="statsPauseTerm" data-message="statsPauseTerm"></dt>
-					<dd>
-					<span id="pause">&mdash;</span>ms
-					<details class="floaty">
-						<summary class="definition" aria-labelledby="define-statsPauseTerm statsPauseTerm">
-							<span id="define-statsPauseTerm" data-message="statsDefine" class="visually-hidden"></span>
-						</summary>
-						<p data-message="statsPauseDefinition"></p>
-					</details>
-					</dd>
+			<dt id="statsPauseTerm" data-message="statsPauseTerm"></dt>
+			<dd>
+				<span id="pause">&mdash;</span>ms
+				<details class="floaty">
+					<summary class="definition" aria-labelledby="define-statsPauseTerm statsPauseTerm">
+						<span id="define-statsPauseTerm" data-message="statsDefine" class="visually-hidden"></span>
+					</summary>
+					<p data-message="statsPauseDefinition"></p>
+				</details>
+			</dd>
 
-					<dt id="statsDurationTerm" data-message="statsDurationTerm"></dt>
-					<dd>
-					<span id="duration">&mdash;</span>ms
-					<details class="floaty">
-						<summary class="definition" aria-labelledby="define-statsDurationTerm statsDurationTerm">
-							<span id="define-statsDurationTerm" data-message="statsDefine" class="visually-hidden"></span>
-						</summary>
-						<p data-message="statsDurationDefinition"></p>
-					</details>
-					</dd>
-				</dl>
-			</details>
+			<dt id="statsDurationTerm" data-message="statsDurationTerm"></dt>
+			<dd>
+				<span id="duration">&mdash;</span>ms
+				<details class="floaty">
+					<summary class="definition" aria-labelledby="define-statsDurationTerm statsDurationTerm">
+						<span id="define-statsDurationTerm" data-message="statsDefine" class="visually-hidden"></span>
+					</summary>
+					<p data-message="statsDurationDefinition"></p>
+				</details>
+			</dd>
+			</dl>
 		</div>
 
 		<script src="GUIJS"></script>

--- a/src/code/_devtoolsRoot.js
+++ b/src/code/_devtoolsRoot.js
@@ -3,4 +3,10 @@ import './compatibility'
 browser.devtools.panels.create(
 	'Landmarks',
 	'landmarks-32.png',
-	'devtoolsPanel.html')
+	'dummyDevToolsPanel.html')
+
+browser.devtools.panels.elements.createSidebarPane(
+	'Landmarks',
+	function(sidebarPane) {
+		sidebarPane.setPage('devtoolsPanel.html')
+	})

--- a/src/static/devtoolsPanel.css
+++ b/src/static/devtoolsPanel.css
@@ -1,33 +1,17 @@
-html { height: 100%; }
-
-body {
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-}
-
-#content { flex-grow: 1; }
-
-#mutation-observation-station {
-	padding-left: 0.5rem;
-	padding-right: 0.5rem;
-}
-
 h1 {
 	margin: 0;
 	font-size: 1rem;
 }
 
-summary > h1 { display: inline-block; }
-
-summary:hover > h1,
-details[open] summary h1 {
-	color: var(--background-1);
-	border-color: var(--background-1);
+#mutation-observation-station {
+	/* TODO: make custom properties for these, or use existing? */
+	padding-left: 0.5rem;
+	padding-right: 0.5rem;
 }
 
-details details { display: inline; }
-details details p { position: absolute; }
+details.floaty { display: inline; }
+details.floaty p { position: absolute; }
+
 summary.definition { list-style: none; }
 summary.definition::-webkit-details-marker { display: none; }
 
@@ -37,8 +21,4 @@ summary.definition::after {
 	margin: var(--top-padding);
 	padding-left: var(--top-padding);
 	padding-right: var(--top-padding);
-}
-
-@media screen and (orientation: landscape) {
-	body { flex-direction: row; }
 }

--- a/src/static/dummyDevToolsPanel.html
+++ b/src/static/dummyDevToolsPanel.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title></title>
+		<link rel="stylesheet" href="common.css">
+		<link rel="stylesheet" href="common.gui.css">
+		<style>
+body { margin: var(--sibling-gap); }
+		</style>
+	</head>
+	<body>
+		<h1>The Landmarks extension developer tools have moved</h1>
+		<p><strong>You can now find them in the sidebar on the Inspector/Elements tab.</strong> This allows you to more easily relate the landmark regions on the page to the HTML code behind them.</p>
+		<p>This tab will be removed in a future version of the extension.</p>
+	</body>
+</html>


### PR DESCRIPTION
Thanks to @carmacleod and https://github.com/IBMa/equal-access/ for showing this is possible :-).