### PR TITLE
fix: Work around Partner Center linting bug

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -362,6 +362,27 @@ function mergeMessages(browser) {
 			: {}
 	}
 
+	// Microsoft Partner Center has a linting bug whereby it fails to implement
+	// the conventional browser extension message look-up technique. Demo repo:
+	// https://github.com/matatk/partner-center-linting-bug
+	//
+	// An internal bug (Edge or Partner Center) was filed with ID 31045320
+	if (browser === 'edge') {
+		for (const locale of ['en_GB', 'en_US']) {
+			const destinationDir = builtLocaleDir(browser, locale)
+			const destinationFile = builtMessagesFile(browser, locale)
+			fse.ensureDirSync(destinationDir)
+			const fallbackMessagesJson = locale === 'en_GB'
+				? {}
+				: getMessagesOrEmpty('en_GB', 'common')
+			const commonMessagesJson = getMessagesOrEmpty(locale, 'common')
+			const merged = merge(fallbackMessagesJson, commonMessagesJson)
+			fs.writeFileSync(destinationFile, JSON.stringify(merged, null, 2))
+			ok(`messages.json written for Edge with workaround for ${locale}.`)
+		}
+		return
+	}
+
 	for (const locale of ['en_GB', 'en_US']) {
 		const destinationDir = builtLocaleDir(browser, locale)
 		const destinationFile = builtMessagesFile(browser, locale)

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -59,13 +59,8 @@
 				<h2>What's new?</h2>
 				<p>New in version <span id="version"></span>&hellip;</p>
 				<ul>
-					<li>Landmark regions that are semantically hidden (via the <code>aria-hidden</code> or <code>inert</code> attributes) are ignored. This means, for example, that landmarks behind modal dialogs (which are unreachable) won't show up any more.</li>
-					<li>New logo/icon. The idea behind the "waypoint flag" is to represent how the extension helps you navigate between markers that the page author has called out.</li>
-					<li>The new logo is designed to have decent contrast in both light and dark UI modes.</li>
-					<li>Several fixes and refinements relating to dark mode.</li>
-					<li>DevTools UI streamlining.</li>
-					<li>Quite a bit of behind-the-scenes/infrastructure polish (e.g. the build process is much faster generally).</li>
-					<li>New screengrabs and promotional image for the browsers' extension stores.</li>
+					<li><mark>TODO</mark></li>
+					<li><strong>Edge users:</strong> version 2.8.0 was not available for Edge due to an issue with the system used for uploading extensions. The Edge team is looking into it, and I've developed a work-around, so we are back on now. Please <a href="https://github.com/matatk/landmarks/blob/master/CHANGELOG.md#280-2020-07-25">check out what was new in version 2.8.0</a> so that you don't miss out on any of the info.</li>
 				</ul>
 				<p>For full details, consult the <a href="https://github.com/matatk/landmarks/blob/master/CHANGELOG.md#landmarks-changelog">change log</a>.</p>
 			</div>


### PR DESCRIPTION
* Build the messages file differently for Edge, so that the Partner
  Center linter accepts the extension upload.
* Mention Edge info in help, to direct users to the 2.8.0 release notes.