### PR TITLE
fix(Profiling): Get the timing part working again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ _site
 .jekyll-metadata
 .nyc_output
 coverage
+scripts/rolledLandmarksFinder.js

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ _site
 .jekyll-metadata
 .nyc_output
 coverage
-scripts/rolledLandmarksFinder.js
+scripts/wrappedLandmarksFinder.js

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -610,13 +610,14 @@ async function main() {
 	const action = isFullBuild ? 'Building' : 'Cleaning'
 	console.log(chalk.bold(`${action} ${extName} ${extVersion}...`))
 	const debugMode = argv.debug === true
+	const debugMsg = debugMode ? ' (debug)' : ''
 
 	testMode = argv.testRelease === true
-	const testModeMessage = testMode ? ' (test version)' : ''
+	const testMsg = testMode ? ' (test)' : ''
 
 	for (const browser of browsers) {
 		console.log()
-		logStep(chalk.bold(`${action} for ${browser}${testModeMessage}`))
+		logStep(chalk.bold(`${action} for ${browser}${testMsg}${debugMsg}`))
 		clean(browser)
 		if (isFullBuild) {
 			copyStaticFiles(browser)

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -88,21 +88,29 @@ async function insertLandmark(page, repetition) {
 //
 
 async function rollLandmarksFinder() {
+	const inputPath = path.join('src', 'code', 'landmarksFinder.js')
 	const outputPath = path.join('scripts', 'rolledLandmarksFinder.js')
-	const bundle = await rollup.rollup({
-		input: path.join('src', 'code', 'landmarksFinder.js')
-	})
-	await bundle.write({
-		file: outputPath,
-		format: 'cjs',
-		exports: 'default'
-	})
+
+	const inputModified = fs.statSync(inputPath).mtime
+	const outputModified = fs.existsSync(outputPath)
+		? fs.statSync(outputPath).mtime
+		: null
+
+	if (!fs.existsSync(outputPath) || inputModified > outputModified) {
+		console.log('Rolluping', inputPath, 'to', outputPath)
+		const bundle = await rollup.rollup({ input: inputPath })
+		await bundle.write({
+			file: outputPath,
+			format: 'cjs',
+			exports: 'default'
+		})
+	}
+
 	return outputPath
 }
 
 async function timeLandmarksFinding(sites, loops) {
 	const landmarksFinderPath = await rollLandmarksFinder()
-	console.log(landmarksFinderPath)
 	const results = {}
 
 	console.log(`Runing landmarks loop test on ${sites}...`)
@@ -158,7 +166,7 @@ function printAndSaveResults(results, loops) {
 		.replace(/:/, '')
 	const fileName = `times--${loops}--${roughlyNow}.json`
 	fs.writeFileSync(fileName, resultsJson)
-	console.log(`${fileName} written to disk.`)
+	console.log(`${fileName} written.`)
 }
 
 

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -120,6 +120,7 @@ async function timeLandmarksFinding(sites, loops) {
 			console.log(`Running landmark-finding code ${loops} times...`)
 			const durations = await page.evaluate(scanAndTallyDurations, loops)
 			results[site] = {
+				url: urls[site],
 				mean: stats.mean(durations),
 				standardDeviation: stats.stdev(durations)
 			}

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -89,7 +89,7 @@ async function insertLandmark(page, repetition) {
 
 async function rollLandmarksFinder() {
 	const inputPath = path.join('src', 'code', 'landmarksFinder.js')
-	const outputPath = path.join('scripts', 'rolledLandmarksFinder.js')
+	const outputPath = path.join('scripts', 'wrappedLandmarksFinder.js')
 
 	const inputModified = fs.statSync(inputPath).mtime
 	const outputModified = fs.existsSync(outputPath)


### PR DESCRIPTION
* Use rollup to make a version of the LandmarksFinder code that can be run via puppeteer (this had been unintentionally broken by #385).
* Rollup is only run if the source has changed since last time.
* Make the build script clearer when building a debug (as opposed to test) build.