### PR TITLE
perf(Profiling): Record more timing info

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 build/
 _site/
 generated-*.js
+scripts/wrappedLandmarksFinder.js

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -14,6 +14,8 @@ const urls = Object.freeze({
 	googledoc: 'https://docs.google.com/document/d/1GPFzG-d47qsD1QjkCCel4-Gol6v34qduFMIhBsGUSTs'
 })
 const pageSettlingDelay = 2e3
+const wrapSourcePath = path.join('src', 'code', 'landmarksFinder.js')
+const wrapOutputPath = path.join('scripts', 'wrappedLandmarksFinder.js')
 const debugBuildNote = 'Remember to run this with a debug build of the extension (i.e. `node scripts/build.js --debug --browser chrome`).'
 
 
@@ -119,25 +121,22 @@ async function doTimeLandmarksFinding(sites, loops) {
 }
 
 async function wrapLandmarksFinder() {
-	const inputPath = path.join('src', 'code', 'landmarksFinder.js')
-	const outputPath = path.join('scripts', 'wrappedLandmarksFinder.js')
-
-	const inputModified = fs.statSync(inputPath).mtime
-	const outputModified = fs.existsSync(outputPath)
-		? fs.statSync(outputPath).mtime
+	const inputModified = fs.statSync(wrapSourcePath).mtime
+	const outputModified = fs.existsSync(wrapOutputPath)
+		? fs.statSync(wrapOutputPath).mtime
 		: null
 
-	if (!fs.existsSync(outputPath) || inputModified > outputModified) {
-		console.log('Rolluping', inputPath, 'to', outputPath)
-		const bundle = await rollup.rollup({ input: inputPath })
+	if (!fs.existsSync(wrapOutputPath) || inputModified > outputModified) {
+		console.log('Rolluping', wrapSourcePath, 'to', wrapOutputPath)
+		const bundle = await rollup.rollup({ input: wrapSourcePath })
 		await bundle.write({
-			file: outputPath,
+			file: wrapOutputPath,
 			format: 'cjs',
 			exports: 'default'
 		})
 	}
 
-	return outputPath
+	return wrapOutputPath
 }
 
 function scanAndTallyDurations(times) {

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -91,7 +91,7 @@ async function insertLandmark(page, repetition) {
 
 async function doTimeLandmarksFinding(sites, loops) {
 	const landmarksFinderPath = await wrapLandmarksFinder()
-	const results = {}
+	const results = { 'meta': { 'loops': loops }, 'sites': {} }
 
 	console.log(`Runing landmarks loop test on ${sites}...`)
 	puppeteer.launch().then(async browser => {
@@ -107,7 +107,7 @@ async function doTimeLandmarksFinding(sites, loops) {
 			})
 			console.log(`Running landmark-finding code ${loops} times...`)
 			const durations = await page.evaluate(scanAndTallyDurations, loops)
-			results[site] = {
+			results['sites'][site] = {
 				url: urls[site],
 				mean: stats.mean(durations),
 				standardDeviation: stats.stdev(durations)
@@ -151,9 +151,10 @@ function scanAndTallyDurations(times) {
 	return durations
 }
 
-function printAndSaveResults(results, loops) {
-	const rounder = (key, value) =>
-		value.toPrecision ? Number(value.toPrecision(2)) : value
+function printAndSaveResults(results) {
+	const rounder = (key, value) => key !== 'loops' && value.toPrecision
+		? Number(value.toPrecision(2))
+		: value
 	console.log()
 	console.log('Done.\nResults (times are in ms):')
 	const resultsJson = JSON.stringify(results, rounder, 2)
@@ -163,7 +164,7 @@ function printAndSaveResults(results, loops) {
 		.replace(/T/, '-')
 		.replace(/:\d\d\..+/, '')
 		.replace(/:/, '')
-	const fileName = `times--${loops}--${roughlyNow}.json`
+	const fileName = `times--${roughlyNow}.json`
 	fs.writeFileSync(fileName, resultsJson)
 	console.log(`${fileName} written.`)
 }

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -87,7 +87,7 @@ async function insertLandmark(page, repetition) {
 // Specific landmarksFinder test
 //
 
-async function rollLandmarksFinder() {
+async function wrapLandmarksFinder() {
 	const inputPath = path.join('src', 'code', 'landmarksFinder.js')
 	const outputPath = path.join('scripts', 'wrappedLandmarksFinder.js')
 
@@ -110,7 +110,7 @@ async function rollLandmarksFinder() {
 }
 
 async function timeLandmarksFinding(sites, loops) {
-	const landmarksFinderPath = await rollLandmarksFinder()
+	const landmarksFinderPath = await wrapLandmarksFinder()
 	const results = {}
 
 	console.log(`Runing landmarks loop test on ${sites}...`)

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -127,7 +127,7 @@ async function wrapLandmarksFinder() {
 		: null
 
 	if (!fs.existsSync(wrapOutputPath) || inputModified > outputModified) {
-		console.log('Rolluping', wrapSourcePath, 'to', wrapOutputPath)
+		console.log('Wrapping', wrapSourcePath, 'as', wrapOutputPath)
 		const bundle = await rollup.rollup({ input: wrapSourcePath })
 		await bundle.write({
 			file: wrapOutputPath,

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -15,6 +15,12 @@ const urls = Object.freeze({
 })
 const wrapSourcePath = path.join('src', 'code', 'landmarksFinder.js')
 const wrapOutputPath = path.join('scripts', 'wrappedLandmarksFinder.js')
+const pageSettleDelay = 4e3
+
+const roundKeys = new Set([
+	'meanScanTime',
+	'standardDeviation',
+	'interactiveElementPercent'])
 const debugBuildNote = 'Remember to run this with a debug build of the extension (i.e. `node scripts/build.js --debug --browser chrome`).'
 
 
@@ -177,10 +183,6 @@ function scanDurationsAndInfo(times) {
 }
 
 function rounder(key, value) {
-	const roundKeys = new Set([
-		'meanScanTime',
-		'standardDeviation',
-		'interactiveElementPercent'])
 	if (roundKeys.has(key)) {
 		return Number(value.toPrecision(2))
 	}
@@ -262,7 +264,8 @@ async function goToAndSettle(page, url) {
 	// that on some pages an extra wait was needed, or the number of elements
 	// found on the page varied a lot.
 	await page.goto(url, { waitUntil: 'networkidle2' })
-	await page.waitForTimeout(4e3)
+	console.log('Page loaded; settling...')
+	await page.waitForTimeout(pageSettleDelay)
 }
 
 function main() {

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -155,7 +155,7 @@ function printAndSaveResults(results, loops) {
 	const rounder = (key, value) =>
 		value.toPrecision ? Number(value.toPrecision(2)) : value
 	console.log()
-	console.log('Done.\nResults (mean time in ms for one landmarks sweep):')
+	console.log('Done.\nResults (times are in ms):')
 	const resultsJson = JSON.stringify(results, rounder, 2)
 	console.log(resultsJson)
 	const roughlyNow = new Date()


### PR DESCRIPTION
* Record the number of elements on each page, including interactive elements and the percentage of interactive elements.
* Record the number of landmarks found on each page.
* Pass through messages from the browser to the console when doing headless profiling.
* Fix some errors that became apparent when passing through browser messages.
* Use the "networkidle2" event to regard the page content as fully loaded; still pause to allow the page to settle (it was found to be necessary, per the comments).
* Rename some functions for clarity.