### PR TITLE
perf(Profiling): Cache sites; Test focus-based navigation; Add test sites

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
 build/
 _site/
 generated-*.js
-scripts/wrappedLandmarksFinder.js
+wrappedLandmarksFinder.js

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ _site
 .jekyll-metadata
 .nyc_output
 coverage
-scripts/wrappedLandmarksFinder.js
+scripts/profile-cache

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -10,7 +10,7 @@ const stats = require('stats-lite')
 const urls = Object.freeze({
 	abootstrap: 'https://angular-ui.github.io/bootstrap/',
 	amazon: 'https://www.amazon.co.uk',
-	ars: 'https://arstechnica.com',  // FIXME: trace doesn't work on cached page
+	ars: 'https://arstechnica.com',
 	bbcnews: 'https://www.bbc.co.uk/news',
 	googledoc1: 'https://docs.google.com/document/d/\
 		1GPFzG-d47qsD1QjkCCel4-Gol6v34qduFMIhBsGUSTs',
@@ -325,7 +325,7 @@ async function load(page, site) {
 	const url = urls[site]
 
 	if (fs.existsSync(cachedPage)) {
-		console.log(`Using cached ${cachedPage}`)
+		console.log(`Using cached ${path.basename(cachedPage)}`)
 
 		await page.setRequestInterception(true)
 		page.on('request', request => {

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -10,12 +10,16 @@ const stats = require('stats-lite')
 const urls = Object.freeze({
 	abootstrap: 'https://angular-ui.github.io/bootstrap/',
 	amazon: 'https://www.amazon.co.uk',
+	amazonproduct: 'https://www.amazon.co.uk/'
+		+ 'Ridleys-Corny-Classic-Provide-Laughs/dp/B07DX65CP1',
 	ars: 'https://arstechnica.com',
 	bbcnews: 'https://www.bbc.co.uk/news',
-	googledoc1: 'https://docs.google.com/document/d/\
-		1GPFzG-d47qsD1QjkCCel4-Gol6v34qduFMIhBsGUSTs',
-	googledoc2: 'https://docs.google.com/document/d/\
-		1FvmYUC0S0BkdkR7wZsg0hLdKc_qjGnGahBwwa0CdnHE'
+	bbcnewsarticle: 'https://www.bbc.co.uk/news/technology-53093613',
+	bbcnewsstory: 'https://www.bbc.co.uk/news/resources/idt-sh/'
+		+ 'dundee_the_city_with_grand_designs',
+	googledoc: 'https://docs.google.com/document/d/'
+		+ '1FvmYUC0S0BkdkR7wZsg0hLdKc_qjGnGahBwwa0CdnHE',
+	wikipediaarticle: 'https://en.wikipedia.org/wiki/Color_blindness'
 })
 const cacheDir = path.join(__dirname, 'profile-cache')
 const wrapSourcePath = path.join(

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -169,6 +169,7 @@ async function doTimeLandmarksFinding(sites, loops, doScan, doFocus) {
 			const combined = fullResults['combined']
 
 			combined.numElements = totalElements
+			combined.elementsPerPage = totalElements / sites.length
 			combined.numInteractiveElements = totalInteractiveElements
 			combined.interactiveElementsPercent =
 				(totalInteractiveElements / totalElements) * 100


### PR DESCRIPTION
* Cache sites so that tests are more consistent over a short timespan at least.
* Add tests for navigation from the focused element (both forward and back) in support of #395.
* Numerous code clean-ups/improvements.
* Store totals/overall averages in the results (not sure how good of an idea this is).