### PR TITLE
feat: Navigate from focused element

### DIFF
--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -61,7 +61,7 @@ function messageHandler(message) {
 		case 'toggle-all-landmarks':
 			// Triggered by keyboard shortcut
 			checkAndUpdateOutdatedResults()
-			if (thereMustBeLandmarks()) {
+			if (checkThereAreLandmarks()) {
 				if (elementFocuser.isManagingBorders()) {
 					elementFocuser.manageBorders(false)
 					borderDrawer.replaceCurrentBordersWithElements(
@@ -109,7 +109,7 @@ function checkAndUpdateOutdatedResults() {
 	return false
 }
 
-function thereMustBeLandmarks() {
+function checkThereAreLandmarks() {
 	if (landmarksFinder.getNumberOfLandmarks() === 0) {
 		alert(browser.i18n.getMessage('noLandmarksFound'))
 		return false
@@ -118,7 +118,7 @@ function thereMustBeLandmarks() {
 }
 
 function checkFocusElement(callbackReturningElementInfo) {
-	if (thereMustBeLandmarks()) {
+	if (checkThereAreLandmarks()) {
 		elementFocuser.focusElement(callbackReturningElementInfo())
 	}
 }

--- a/src/code/landmarksFinder.js
+++ b/src/code/landmarksFinder.js
@@ -391,7 +391,9 @@ export default function LandmarksFinder(win, doc) {
 	this.getNextLandmarkElementInfo = function() {
 		if (doc.activeElement !== null && doc.activeElement !== doc.body) {
 			const index = getIndexOfNextLandmarkAfter(doc.activeElement)
-			if (index) return updateSelectedIndexAndReturnElementInfo(index)
+			if (index !== null) {
+				return updateSelectedIndexAndReturnElementInfo(index)
+			}
 		}
 		return updateSelectedIndexAndReturnElementInfo(
 			(currentlySelectedIndex + 1) % landmarks.length)
@@ -400,7 +402,9 @@ export default function LandmarksFinder(win, doc) {
 	this.getPreviousLandmarkElementInfo = function() {
 		if (doc.activeElement !== null && doc.activeElement !== doc.body) {
 			const index = getIndexOfPreviousLandmarkAfter(doc.activeElement)
-			if (index) return updateSelectedIndexAndReturnElementInfo(index)
+			if (index !== null) {
+				return updateSelectedIndexAndReturnElementInfo(index)
+			}
 		}
 		return updateSelectedIndexAndReturnElementInfo(
 			(currentlySelectedIndex <= 0) ?

--- a/src/code/landmarksFinder.js
+++ b/src/code/landmarksFinder.js
@@ -331,10 +331,10 @@ export default function LandmarksFinder(win, doc) {
 	//
 
 	function getIndexOfNextLandmarkAfter(element) {
-		for (const [index, landmark] of landmarks.entries()) {
-			const rels = element.compareDocumentPosition(landmark.element)
+		for (let i = 0; i < landmarks.length; i++) {
+			const rels = element.compareDocumentPosition(landmarks[i].element)
 			// eslint-disable-next-line no-bitwise
-			if (rels & Node.DOCUMENT_POSITION_FOLLOWING) return index
+			if (rels & Node.DOCUMENT_POSITION_FOLLOWING) return i
 		}
 		return null
 	}

--- a/src/code/landmarksFinder.js
+++ b/src/code/landmarksFinder.js
@@ -329,42 +329,11 @@ export default function LandmarksFinder(win, doc) {
 
 	// TODO: experimental stuff for focus handling
 
-	function checkForLandmarks(element, skipSelf) {
-		if (!skipSelf) {
-			if (_landmarkElementsOnly.includes(element)) {
-				return element
-			}
+	function comparePosition(element) {
+		for (const landmark of _landmarkElementsOnly) {
+			const rels = element.compareDocumentPosition(landmark)
+			if (rels & Node.DOCUMENT_POSITION_FOLLOWING) return landmark
 		}
-		for (const child of element.children) {
-			let found
-			if ((found = checkForLandmarks(child)) !== null) {
-				return found
-			}
-		}
-		return null
-	}
-
-	function tryToFind(current, skipSelf) {
-		let check = current
-		while (check) {
-			const selfAndChildren = checkForLandmarks(check, skipSelf)
-			if (selfAndChildren) return selfAndChildren
-			skipSelf = false
-
-			let sibling = check
-			while ((sibling = sibling.nextElementSibling) !== null) {
-				const siblingLandmark = checkForLandmarks(sibling)
-				if (siblingLandmark) return siblingLandmark
-			}
-
-			// TODO: If <body> is a landmark it won't be found?
-			let next = check
-			do {
-				next = next.parentElement
-			} while (next !== doc.body && next.nextElementSibling === null)
-			check = next.nextElementSibling
-		}
-		return null
 	}
 
 
@@ -410,10 +379,10 @@ export default function LandmarksFinder(win, doc) {
 
 	this.getNextLandmarkElementInfo = function() {
 		if (doc.activeElement !== null && doc.activeElement !== doc.body) {
-			const found = tryToFind(doc.activeElement, true)
-			const foundIndex = _landmarkElementsOnly.indexOf(found)
+			const found = comparePosition(doc.activeElement)
 			if (found) {
-				return updateSelectedIndexAndReturnElementInfo(foundIndex)
+				const index = _landmarkElementsOnly.indexOf(found)
+				return updateSelectedIndexAndReturnElementInfo(index)
 			}
 		}
 		return updateSelectedIndexAndReturnElementInfo(

--- a/test/manual-test-focus-navigation-order.html
+++ b/test/manual-test-focus-navigation-order.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title>Focus and navigation order test</title>
+		<style>
+* { box-sizing: border-box; }
+
+html, body { height: 100%; }
+
+body {
+	display: flex;
+	flex-direction: column;
+	margin: 0;
+	padding: 0.5rem;
+	padding-top: 0;
+}
+
+header, nav, main, aside, footer, section {
+	border: 0.15rem solid black;
+	margin-top: 0.5rem;
+	padding: 0.5rem;
+}
+
+.content {
+	flex-grow: 1;
+	display: flex;
+}
+
+nav { width: 20vw; }
+
+main {
+	flex-grow: 1;
+	margin-left: 0.5rem;
+	margin-right: 0.5rem;
+}
+
+aside { width: 30vw; }
+
+button {
+	font-size: inherit;
+	background: #757575;
+	color: white;
+	border: 0;
+	padding: 0.25rem;
+	padding-left: 0.5rem;
+	padding-right: 0.5rem;
+}
+
+:focus {
+	outline: 0.25rem solid green;
+	outline-offset: 0.15rem;
+}
+
+.test-area {
+	background: lightgray;
+	padding: 1rem;
+}
+.test-area + .test-area { margin-top: 1rem; }
+
+.test-unbalancer {
+	padding: 1rem;
+	margin-top: 1rem;
+	border: 0.15rem dashed black;
+}
+.test-unbalancer p { margin-top: 0; }
+		</style>
+	</head>
+	<body>
+		<header>
+			<h1>Focus and navigation order test</h1>
+		</header>
+
+		<p>This is outside of all landmarks. By the way, a green outline is applied to things that have the focus. And here's <a href="#">a link outwith all landmarks</a>.</p>
+
+		<div class="content">
+			<nav aria-labelledby="nav-title">
+				<h2 id="nav-title">Navigation</h2>
+				<ul>
+					<li><a href="#">Home</a></li>
+					<li><a href="#">News</a></li>
+					<li><a href="#">About</a></li>
+					<li><a href="#">Contact</a></li>
+				</ul>
+			</nav>
+			<main>
+				<h2>Main</h2>
+				<p>Navigating between landmarks focuses the landmark, so pressing <kbd>Tab</kbd> picks up from the current landmark. Navigating between landmarks in turn should pick up from where the focus is.</p>
+
+				<div class="test-area">
+					<section aria-labelledby="title-1">
+						<h2 id="title-1">Nested landmark 1</h2>
+						<p>This is in a nested landmark.</p>
+						<button>Action 1</button>
+					</section>
+
+					<p>This isn't in a nested landmark.</p>
+					<button id="targ">Action 2</button>
+
+					<section aria-labelledby="title-2">
+						<h2 id="title-2">Nested landmark 2</h2>
+						<p>This is in a nested landmark.</p>
+						<button>Action 3</button>
+					</section>
+				</div>
+
+				<div class="test-area">
+					<section aria-labelledby="title-a">
+						<h2 id="title-a">Nested landmark A</h2>
+						<p>This is in a nested landmark.</p>
+						<button>Action A</button>
+					</section>
+
+					<p>This isn't in a nested landmark.</p>
+					<button>Action B</button>
+
+					<div class="test-unbalancer">
+						<p>A <code>&lt;div&gt;</code>! :-)</p>
+						<section aria-labelledby="title-b">
+							<h2 id="title-b">Nested landmark B</h2>
+							<p>This is in a nested landmark.</p>
+							<button>Action C</button>
+						</section>
+					</div>
+				</div>
+			</main>
+
+			<aside aria-labelledby="aside-title">
+				<h2 id="aside-title">Aside</h2>
+				<p>Hello.</p>
+				<button id="frag">Focus &quot;Action 2&quot; button</button>
+			</aside>
+		</div>
+
+		<footer>
+			<p>Footer.</p>
+			<p><a href="#">Site map</a></p>
+		</footer>
+
+		<script>
+			document.getElementById('frag').onclick = function() {
+				document.getElementById('targ').focus();
+			};
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
If there is a focused element in the document, navigate from its position when moving forward/backward between landmarks.

A test page for manual testing was added, and improvements to profiling allowed some good measurements. Was quite fun experimenting with more effective ways to do things.

Resolves #395