### PR TITLE
feat: More in-keeping DevTools style

### DIFF
--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -110,6 +110,7 @@
 				</details>
 			</dd>
 			</dl>
+			<p data-message="statsInfo"></p>
 		</div>
 		<!-- /devtools -->
 

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -58,7 +58,7 @@
 				<dt id="statsMutationsTerm" data-message="statsMutationsTerm"></dt>
 				<dd>
 					<span id="mutations">0</span>
-					<details class="floaty">
+					<details>
 						<summary class="definition" aria-labelledby="define-statsMutationsTerm statsMutationsTerm">
 							<span id="define-statsMutationsTerm" data-message="statsDefine" class="visually-hidden"></span>
 						</summary>
@@ -69,7 +69,7 @@
 				<dt id="statsCheckedMutationsTerm" data-message="statsCheckedMutationsTerm"></dt>
 				<dd>
 					<span id="checks">0</span>
-					<details class="floaty">
+					<details>
 						<summary class="definition" aria-labelledby="define-statsCheckedMutationsTerm statsCheckedMutationsTerm">
 							<span id="define-statsCheckedMutationsTerm" data-message="statsDefine" class="visually-hidden"></span>
 						</summary>
@@ -80,7 +80,7 @@
 				<dt id="statsScansTerm" data-message="statsScansTerm"></dt></dt>
 			<dd>
 				<span id="scans">0</span>
-				<details class="floaty">
+				<details>
 					<summary class="definition" aria-labelledby="define-statsScansTerm statsScansTerm">
 						<span id="define-statsScansTerm" data-message="statsDefine" class="visually-hidden"></span>
 					</summary>
@@ -91,7 +91,7 @@
 			<dt id="statsPauseTerm" data-message="statsPauseTerm"></dt>
 			<dd>
 				<span id="pause">&mdash;</span>ms
-				<details class="floaty">
+				<details>
 					<summary class="definition" aria-labelledby="define-statsPauseTerm statsPauseTerm">
 						<span id="define-statsPauseTerm" data-message="statsDefine" class="visually-hidden"></span>
 					</summary>
@@ -102,7 +102,7 @@
 			<dt id="statsDurationTerm" data-message="statsDurationTerm"></dt>
 			<dd>
 				<span id="duration">&mdash;</span>ms
-				<details class="floaty">
+				<details>
 					<summary class="definition" aria-labelledby="define-statsDurationTerm statsDurationTerm">
 						<span id="define-statsDurationTerm" data-message="statsDefine" class="visually-hidden"></span>
 					</summary>

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -3,29 +3,33 @@
 	<head>
 		<meta charset="UTF-8">
 		<title></title>
+		<!-- popup-and-sidebar -->
 		<link rel="stylesheet" href="common.css">
 		<link rel="stylesheet" href="common.gui.css">
-		<!-- ui -->
+		<!-- sidebar -->
 		<link rel="stylesheet" href="sidebar.css">
-		<!-- /ui -->
+		<!-- /sidebar -->
+		<!-- /popup-and-sidebar -->
 		<!-- devtools -->
 		<link rel="stylesheet" href="devtoolsPanel.css">
 		<!-- /devtools -->
 	</head>  <!-- TODO: this gets aligned wrongly after the replace -->
 	<body>
 		<div id="content">
-			<!-- ui -->
+			<!-- popup-and-sidebar -->
+			<!-- sidebar -->
 			<div id="note-ui" class="warning" hidden>
 				<p data-message="hintSidebarIsNotPrimary"></p>
 				<button id="note-ui-cta" data-message="hintSidebarIsNotPrimaryCTA"></button>
 				<button id="note-ui-dismiss" data-message="hintSidebarIsNotPrimaryDismiss"></button>
 			</div>
-			<!-- /ui -->
+			<!-- /sidebar -->
 			<div id="note-update" class="warning" hidden>
 				<p><span data-message="hintWhatIsNew"></span> <span id="version"></span>.</p>
 				<button id="note-update-cta" data-message="hintWhatIsNewCTA"></button>
 				<button id="note-update-dismiss" data-message="hintWhatIsNewDismiss"></button>
 			</div>
+			<!-- /popup-and-sidebar -->
 			<!-- devtools -->
 			<h1 data-message="extensionShortName"></h1>
 			<div id="connection-error" class="warning" hidden>
@@ -40,10 +44,12 @@
 			</label>
 		</div>
 
-		<div id="links"> <!-- removed in DevTools panel -->
+		<!-- popup-and-sidebar -->
+		<div id="links">
 			<button id="help" data-message="popupHelpButton"></button>
 			<button id="settings" data-message="popupPreferencesButton"></button>
 		</div>
+		<!-- /popup-and-sidebar -->
 
 		<!-- devtools -->
 		<div id="mutation-observation-station">

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -45,7 +45,8 @@
 			<button id="settings" data-message="popupPreferencesButton"></button>
 		</div>
 
-		<div id="mutation-observation-station"> <!-- only in DevTools -->
+		<!-- devtools -->
+		<div id="mutation-observation-station">
 			<h1 data-message="statsHeading"></h1>
 			<dl>
 				<dt id="statsMutationsTerm" data-message="statsMutationsTerm"></dt>
@@ -104,6 +105,7 @@
 			</dd>
 			</dl>
 		</div>
+		<!-- /devtools -->
 
 		<script src="GUIJS"></script>
 	</body>

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -226,6 +226,10 @@
     "message": "Warning: This DevTools frame has become disconnected, probably due to the extension being reloaded. You'll need to reload this frame (e.g. via its context menu) for it to recieve updates again."
   },
 
+  "statsInfo": {
+    "message": "This info relates to how the extension is scanning the page for landmarks. When DevTools is open, the page will be scanned using the more detailed and slightly slower \"developer\" version of the scanner."
+  },
+
   "statsHeading": {
     "message": "Mutation information"
   },
@@ -239,7 +243,7 @@
   },
 
   "statsCheckedMutationsTerm": {
-    "message": "Checked Mutations:"
+    "message": "Checked mutations:"
   },
 
   "statsCheckedMutationsDefinition": {

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -325,6 +325,12 @@ function handleMutationMessage(data) {
 	}
 }
 
+function reflectDevToolsTheme(themeName) {
+	console.log('reflectDevToolsTheme:', themeName)
+	document.documentElement.classList = `theme-${themeName}`
+	console.log(document.documentElement.classList)
+}
+
 
 //
 // Start-up
@@ -336,9 +342,7 @@ function handleMutationMessage(data) {
 //       really isn't using it, but at least it keeps all the code here, rather
 //       than putting some separately in the build script.
 function startupDevTools() {
-	// TODO: onChanged for Firefox
-	document.documentElement.classList =
-		`theme-${browser.devtools.panels.themeName}`
+	reflectDevToolsTheme(browser.devtools.panels.themeName)
 
 	port = browser.runtime.connect({ name: INTERFACE })
 	if (BROWSER !== 'firefox') {
@@ -346,6 +350,9 @@ function startupDevTools() {
 		port.onDisconnect.addListener(function() {
 			document.getElementById('connection-error').hidden = false
 		})
+	} else {
+		browser.devtools.panels.onThemeChanged.addListener(
+			reflectDevToolsTheme)
 	}
 
 	port.onMessage.addListener(messageHandlerCore)

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -326,9 +326,7 @@ function handleMutationMessage(data) {
 }
 
 function reflectDevToolsTheme(themeName) {
-	console.log('reflectDevToolsTheme:', themeName)
 	document.documentElement.classList = `theme-${themeName}`
-	console.log(document.documentElement.classList)
 }
 
 

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -339,6 +339,10 @@ function handleMutationMessage(data) {
 //       really isn't using it, but at least it keeps all the code here, rather
 //       than putting some separately in the build script.
 function startupDevTools() {
+	// TODO: onChanged for Firefox
+	document.documentElement.classList =
+		`theme-${browser.devtools.panels.themeName}`
+
 	port = browser.runtime.connect({ name: INTERFACE })
 	if (BROWSER !== 'firefox') {
 		// DevTools page doesn't get reloaded when the extension does

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -131,9 +131,8 @@ function makeLandmarksTree(landmarks, container) {
 
 			if (landmark.error) {
 				const details = document.createElement('details')
-				details.setAttribute('class', 'floaty')
 				const summary = document.createElement('summary')
-				summary.setAttribute('class', 'definition lint-warning')
+				summary.setAttribute('class', 'lint-warning')
 				summary.setAttribute('aria-label', `Warning for ${landmark.role}`)
 				const para = document.createElement('p')
 				para.appendChild(document.createTextNode(landmark.error))

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -367,8 +367,6 @@ function startupPopupOrSidebar() {
 	makeEventHandlers('help')
 	makeEventHandlers('settings')
 
-	document.getElementById('mutation-observation-station').remove()
-
 	// The message could be coming from any content script or other GUI, so
 	// it needs to be filtered. (The background script filters out messages
 	// for the DevTools panel.)

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -116,19 +116,6 @@ function makeLandmarksTree(landmarks, container) {
 		item.appendChild(button)
 
 		if (INTERFACE === 'devtools') {
-			if (landmark.error) {
-				const details = document.createElement('details')
-				details.setAttribute('class', 'floaty')
-				const summary = document.createElement('summary')
-				summary.setAttribute('class', 'definition lint-warning')
-				summary.setAttribute('aria-label', `Warning for ${landmark.role}`)
-				const para = document.createElement('p')
-				para.appendChild(document.createTextNode(landmark.error))
-				details.appendChild(summary)
-				details.appendChild(para)
-				item.appendChild(details)
-			}
-
 			const inspectButton = makeSymbolButton(
 				function() {
 					const inspectorCall = "inspect(document.querySelector('"
@@ -141,6 +128,19 @@ function makeLandmarksTree(landmarks, container) {
 				landmarkName(landmark))
 			inspectButton.title = landmark.selector
 			item.appendChild(inspectButton)
+
+			if (landmark.error) {
+				const details = document.createElement('details')
+				details.setAttribute('class', 'floaty')
+				const summary = document.createElement('summary')
+				summary.setAttribute('class', 'definition lint-warning')
+				summary.setAttribute('aria-label', `Warning for ${landmark.role}`)
+				const para = document.createElement('p')
+				para.appendChild(document.createTextNode(landmark.error))
+				details.appendChild(summary)
+				details.appendChild(para)
+				item.appendChild(details)
+			}
 		}
 
 		base.appendChild(item)  // add to current base

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -339,9 +339,6 @@ function handleMutationMessage(data) {
 //       really isn't using it, but at least it keeps all the code here, rather
 //       than putting some separately in the build script.
 function startupDevTools() {
-	document.getElementById('note-update').remove()
-	document.getElementById('links').remove()
-
 	port = browser.runtime.connect({ name: INTERFACE })
 	if (BROWSER !== 'firefox') {
 		// DevTools page doesn't get reloaded when the extension does

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -181,8 +181,6 @@ function makeButtonAlreadyTranslated(onClick, name, symbol, context) {
 	button.appendChild(document.createTextNode(symbol ? symbol : name))
 	if (symbol) {
 		button.setAttribute('aria-label', name + ' ' + context)
-		button.style.border = 'none'
-		button.style.background = 'none'
 	}
 	button.onclick = onClick
 	return button

--- a/src/static/devtoolsPanel.css
+++ b/src/static/devtoolsPanel.css
@@ -1,10 +1,12 @@
 @-moz-document url-prefix() {
 	/* Hacks for Firefox */
 
-	/* The font is not resizable on Firefox, and by default it's
-	   significantly bigger than the other panels' font. Doing this to fit in,
-	   on the assumption that people using magnifiers will have to zoom the
-	   whole screen anyway :-S. */
+	/* The font is not resizable on Firefox—whilst the text size on other
+	   panels does grow when zooming, I've never managed to make this work
+	   here. Not sure if it's me or Firefox's in-built CSS.
+
+	   Refs: <https://stackoverflow.com/q/27273389/1485308> and
+	   <https://bugzilla.mozilla.org/show_bug.cgi?id=1319367> */
 	html { font-size: 12px; }
 
 	/* The buttons and summaries are aligned differently. */

--- a/src/static/devtoolsPanel.css
+++ b/src/static/devtoolsPanel.css
@@ -1,29 +1,48 @@
-:root {
-	--border: 1px solid gray;
+* { box-sizing: border-box; }
+
+html {
+	--text: black;
+	--bkg: white;
+	--thin-accent: gray;
+	--thick-accent: #eee;
+
+	/* Shared */
+	--border: 1px solid var(--thin-accent);
 	--spacing: 0.15rem;
-	--x-padding: 0.25rem;
-	--y-padding: 0.5rem;
+	--padding: 0.25rem;
+	--big-padding: 0.5rem;
 }
 
-* { box-sizing: border-box; }
-html { font-size: 85%; }  /* to match other panels */
+html.theme-dark {
+	--text: white;
+	--bkg: black;
+	--thin-accent: #6b6b6b;
+	--thick-accent: #444;
+}
 
 body {
 	font-family: sans-serif;
 	margin: 0;
+	color: var(--text);
+}
+
+button {
+	font-size: inherit;
+	color: var(--text);
+	background-color: unset;
+	border: var(--border);
 }
 
 body > div > * {
-	padding: var(--x-padding);
-	padding-top: var(--y-padding);
-	padding-bottom: var(--y-padding);
+	padding: var(--big-padding);
+	padding-top: var(--padding);
+	padding-bottom: var(--padding);
 }
 
 h1 {
 	margin: 0;
 	font-size: 1rem;
-	background: #eee;
-	border-bottom: var(--border);
+	background: var(--thick-accent);
 }
 
 ul {
@@ -38,32 +57,32 @@ li {
 	margin-top: var(--spacing);
 }
 
-button { font-size: inherit; }
-
-#show-all-label { margin-top: var(--y-padding); }
-
-#mutation-observation-station { margin-top: var(--x-padding); }
+#show-all-label,
+#mutation-observation-station { margin-top: var(--big-padding); }
 
 p { margin-top: 0; }
 
 details > p {
 	margin: 0;
-	padding: var(--x-padding);
-	background-color: white;
+	padding: var(--padding);
+	background-color: var(--bkg);
 	border: var(--border);
 }
 
 details.floaty { display: inline; }
 details.floaty p { position: absolute; }
+
 summary { border: var(--border); }
-summary.definition { list-style: none; }
+
+summary.definition { list-style: none; }  /* for Firefox */
 summary.definition::-webkit-details-marker { display: none; }
-summary.definition.lint-warning::after { content: "⚠️"; }
 
 summary.definition::after {
 	content: "?";
-	padding: var(--y-padding);
+	padding: var(--big-padding);
 }
+
+summary.definition.lint-warning::after { content: "⚠️"; }
 
 dl {
 	display: flex;

--- a/src/static/devtoolsPanel.css
+++ b/src/static/devtoolsPanel.css
@@ -1,5 +1,3 @@
-* { box-sizing: border-box; }
-
 html {
 	--text: black;
 	--bkg: white;
@@ -30,7 +28,6 @@ button {
 	font-size: inherit;
 	color: var(--text);
 	background-color: unset;
-	border: var(--border);
 }
 
 body > div > * {
@@ -54,7 +51,7 @@ ul ul { padding-left: 2rem; }
 
 li {
 	display: block;
-	margin-top: var(--spacing);
+	margin-top: var(--padding);
 }
 
 #show-all-label,
@@ -72,17 +69,29 @@ details > p {
 details.floaty { display: inline; }
 details.floaty p { position: absolute; }
 
-summary { border: var(--border); }
-
-summary.definition { list-style: none; }  /* for Firefox */
+summary.definition { list-style: none; }  /* for disclosure symbol in Firefox */
 summary.definition::-webkit-details-marker { display: none; }
+summary.definition::after { content: "?"; }
+summary.definition.lint-warning::after { content: "⚠️"; }
 
-summary.definition::after {
-	content: "?";
-	padding: var(--big-padding);
+button,
+summary {
+	border: var(--border);
+	padding: var(--padding);
+	line-height: 1rem; /* for the glyphs */
 }
 
-summary.definition.lint-warning::after { content: "⚠️"; }
+/* Note: Hack for Firefox, as it positions/aligns the buttons and summary
+         differently; can't think what else I can do here. */
+@-moz-document url-prefix() {
+	summary {
+		position: relative;
+		top: -2px;
+	}
+}
+
+button + button,
+button + details > summary { margin-left: var(--big-padding); }
 
 dl {
 	display: flex;

--- a/src/static/devtoolsPanel.css
+++ b/src/static/devtoolsPanel.css
@@ -1,3 +1,10 @@
+:root {
+	--border: 1px solid gray;
+	--spacing: 0.15rem;
+	--x-padding: 0.25rem;
+	--y-padding: 0.5rem;
+}
+
 * { box-sizing: border-box; }
 html { font-size: 85%; }  /* to match other panels */
 
@@ -7,15 +14,16 @@ body {
 }
 
 body > div > * {
-	padding: 0.5rem;
-	padding-top: 0.25rem;
-	padding-bottom: 0.25rem;
+	padding: var(--x-padding);
+	padding-top: var(--y-padding);
+	padding-bottom: var(--y-padding);
 }
 
 h1 {
 	margin: 0;
 	font-size: 1rem;
-	background: lightgray;
+	background: #eee;
+	border-bottom: var(--border);
 }
 
 ul {
@@ -27,34 +35,34 @@ ul ul { padding-left: 2rem; }
 
 li {
 	display: block;
-	margin-top: 0.15rem;
+	margin-top: var(--spacing);
 }
 
 button { font-size: inherit; }
 
-#show-all-label { margin-top: 0.25rem; }
+#show-all-label { margin-top: var(--y-padding); }
 
-#mutation-observation-station { margin-top: 0.5rem; }
+#mutation-observation-station { margin-top: var(--x-padding); }
 
 p { margin-top: 0; }
 
 details > p {
 	margin: 0;
-	padding: 0.5rem;
+	padding: var(--x-padding);
 	background-color: white;
-	border: 1px solid gray;
+	border: var(--border);
 }
 
 details.floaty { display: inline; }
 details.floaty p { position: absolute; }
-summary { border: 1px solid gray; }
+summary { border: var(--border); }
 summary.definition { list-style: none; }
 summary.definition::-webkit-details-marker { display: none; }
 summary.definition.lint-warning::after { content: "⚠️"; }
 
 summary.definition::after {
 	content: "?";
-	padding: 0.25rem;
+	padding: var(--y-padding);
 }
 
 dl {
@@ -63,9 +71,10 @@ dl {
 	margin: 0;
 }
 
-dt, dd {
-	margin-top: 0.15rem;
-	margin-bottom: 0.15rem;
+dt,
+dd {
+	margin-top: var(--spacing);
+	margin-bottom: var(--spacing);
 }
 
 dt { width: 33%; }

--- a/src/static/devtoolsPanel.css
+++ b/src/static/devtoolsPanel.css
@@ -1,3 +1,19 @@
+@-moz-document url-prefix() {
+	/* Hacks for Firefox */
+
+	/* The font is not resizable on Firefox, and by default it's
+	   significantly bigger than the other panels' font. Doing this to fit in,
+	   on the assumption that people using magnifiers will have to zoom the
+	   whole screen anyway :-S. */
+	html { font-size: 12px; }
+
+	/* The buttons and summaries are aligned differently. */
+	summary {
+		position: relative;
+		top: -1px;
+	}
+}
+
 html {
 	--text: black;
 	--bkg: white;
@@ -30,6 +46,7 @@ button {
 	background-color: unset;
 }
 
+/* Everything that's content is within one of the two main sections */
 body > div > * {
 	padding: var(--big-padding);
 	padding-top: var(--padding);
@@ -59,36 +76,29 @@ li {
 
 p { margin-top: 0; }
 
+details { display: inline; }
+
 details > p {
 	margin: 0;
+	margin-left: var(--padding);
 	padding: var(--padding);
 	background-color: var(--bkg);
 	border: var(--border);
+	position: absolute;
 }
-
-details.floaty { display: inline; }
-details.floaty p { position: absolute; }
-
-summary.definition { list-style: none; }  /* for disclosure symbol in Firefox */
-summary.definition::-webkit-details-marker { display: none; }
-summary.definition::after { content: "?"; }
-summary.definition.lint-warning::after { content: "⚠️"; }
 
 button,
 summary {
 	border: var(--border);
 	padding: var(--padding);
-	line-height: 1rem; /* for the glyphs */
+	line-height: 1rem;  /* for the glyphs */
 }
 
-/* Note: Hack for Firefox, as it positions/aligns the buttons and summary
-         differently; can't think what else I can do here. */
-@-moz-document url-prefix() {
-	summary {
-		position: relative;
-		top: -2px;
-	}
-}
+summary { list-style: none; }  /* for disclosure symbol in Firefox */
+summary::-webkit-details-marker { display: none; }
+
+summary.definition::after { content: "?"; }
+summary.lint-warning::after { content: "⚠️"; }
 
 button + button,
 button + details > summary { margin-left: var(--big-padding); }
@@ -105,7 +115,10 @@ dd {
 	margin-bottom: var(--spacing);
 }
 
-dt { width: 33%; }
+dt {
+	align-self: center;
+	width: 33%;
+}
 
 dd {
 	margin-left: auto;

--- a/src/static/devtoolsPanel.css
+++ b/src/static/devtoolsPanel.css
@@ -8,16 +8,14 @@
 	   Refs: <https://stackoverflow.com/q/27273389/1485308> and
 	   <https://bugzilla.mozilla.org/show_bug.cgi?id=1319367> */
 	html { font-size: 12px; }
+	body { background-color: var(--bkg); }
 
-	/* The buttons and summaries are aligned differently. */
 	summary {
 		position: relative;
 		top: -1px;
 	}
 
-	body {
-		background-color: var(--bkg);
-	}
+	details > p { z-index: 42; }
 }
 
 html {
@@ -86,7 +84,6 @@ details { display: inline; }
 
 details > p {
 	margin: 0;
-	margin-left: var(--padding);
 	padding: var(--padding);
 	background-color: var(--bkg);
 	border: var(--border);

--- a/src/static/devtoolsPanel.css
+++ b/src/static/devtoolsPanel.css
@@ -1,4 +1,5 @@
 * { box-sizing: border-box; }
+html { font-size: 85%; }  /* to match other panels */
 
 body {
 	font-family: sans-serif;
@@ -29,11 +30,13 @@ li {
 	margin-top: 0.15rem;
 }
 
+button { font-size: inherit; }
+
 #show-all-label { margin-top: 0.25rem; }
 
 #mutation-observation-station { margin-top: 0.5rem; }
 
-details[open] > summary { border: 1px solid gray; }
+p { margin-top: 0; }
 
 details > p {
 	margin: 0;
@@ -44,10 +47,33 @@ details > p {
 
 details.floaty { display: inline; }
 details.floaty p { position: absolute; }
+summary { border: 1px solid gray; }
 summary.definition { list-style: none; }
 summary.definition::-webkit-details-marker { display: none; }
-summary.definition::after { content: "?"; }
 summary.definition.lint-warning::after { content: "⚠️"; }
+
+summary.definition::after {
+	content: "?";
+	padding: 0.25rem;
+}
+
+dl {
+	display: flex;
+	flex-wrap: wrap;
+	margin: 0;
+}
+
+dt, dd {
+	margin-top: 0.15rem;
+	margin-bottom: 0.15rem;
+}
+
+dt { width: 33%; }
+
+dd {
+	margin-left: auto;
+	width: 66%;
+}
 
 /* FIXME: DRY with common.css —- it's still in there because common.css is also
  * used on the home page */

--- a/src/static/devtoolsPanel.css
+++ b/src/static/devtoolsPanel.css
@@ -12,6 +12,10 @@
 		position: relative;
 		top: -1px;
 	}
+
+	body {
+		background-color: var(--bkg);
+	}
 }
 
 html {

--- a/src/static/devtoolsPanel.css
+++ b/src/static/devtoolsPanel.css
@@ -1,26 +1,63 @@
+* { box-sizing: border-box; }
+
+body {
+	font-family: sans-serif;
+	margin: 0;
+}
+
+body > div > * {
+	padding: 0.5rem;
+	padding-top: 0.25rem;
+	padding-bottom: 0.25rem;
+}
+
 h1 {
 	margin: 0;
 	font-size: 1rem;
+	background: lightgray;
 }
 
-#mutation-observation-station {
-	/* TODO: make custom properties for these, or use existing? */
-	padding-left: 0.5rem;
-	padding-right: 0.5rem;
+ul {
+	margin: 0;
+	padding: 0;
+}
+
+ul ul { padding-left: 2rem; }
+
+li {
+	display: block;
+	margin-top: 0.15rem;
+}
+
+#show-all-label { margin-top: 0.25rem; }
+
+#mutation-observation-station { margin-top: 0.5rem; }
+
+details[open] > summary { border: 1px solid gray; }
+
+details > p {
+	margin: 0;
+	padding: 0.5rem;
+	background-color: white;
+	border: 1px solid gray;
 }
 
 details.floaty { display: inline; }
 details.floaty p { position: absolute; }
-
 summary.definition { list-style: none; }
 summary.definition::-webkit-details-marker { display: none; }
-
-summary.definition::after {
-	content: "?";
-	border: var(--standard-control-line);
-	margin: var(--top-padding);
-	padding-left: var(--top-padding);
-	padding-right: var(--top-padding);
-}
-
+summary.definition::after { content: "?"; }
 summary.definition.lint-warning::after { content: "⚠️"; }
+
+/* FIXME: DRY with common.css —- it's still in there because common.css is also
+ * used on the home page */
+.visually-hidden {
+	position: absolute !important;
+	clip: rect(1px, 1px, 1px, 1px);
+	padding: 0 !important;
+	border: 0 !important;
+	height: 1px !important;
+	width: 1px !important;
+	overflow: hidden;
+	white-space: nowrap;
+}

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -14,7 +14,7 @@
 		</header>
 
 		<main>
-			<!-- ui -->
+			<!-- sidebar -->
 			<fieldset data-pref="interface">
 				<legend data-message="prefsInterface"></legend>
 
@@ -34,7 +34,7 @@
 					</label>
 				</div>
 			</fieldset>
-			<!-- /ui -->
+			<!-- /sidebar -->
 
 			<fieldset data-pref="borderType">
 				<legend data-message="prefsBorderType"></legend>


### PR DESCRIPTION
* Style the DevTools panel in a way that matches the browsers' DevTools appearance more closely, and makes more use of the available screen space.
* Support light and dark DevTools themes, including theme changes on-the-fly in Firefox.
* Streamline the base gui.html a bit due to the simplified styles, and demarcate the DevTools and non-DevTools parts of the UI in this file completely, rather than having to remove elements in JS after load.
* Streamline the build script a bit in light of the above.
* Also rename the "tag" used to demarcate stuff to do with the sidebar in gui.html and options.html from "ui" to "sidebar" for clarity.
* Add a bit of info abut the mutation stats at the bottom of the DevTools panel.
* Re-order the buttons/warnings disclosure in the DevTools panel to be more consistent.
* Style the buttons/warnings disclosure to look more interactive.
* Fix some layout issues in Firefox (using feature detection—thanks StackOverflow—this could be used for other styling too).

Fixes #405