### PR TITLE
perf: Streamlining scans and messaging; Debugging info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "version": "2.9.0",
       "devDependencies": {
+        "@rollup/plugin-strip": "^2.0.1",
         "addons-linter": "^3.7.0",
         "archiver-promise": "~1.0",
         "ava": "^3.15.0",
@@ -605,6 +606,43 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@rollup/plugin-strip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-strip/-/plugin-strip-2.0.1.tgz",
+      "integrity": "sha512-+JJInHt/90Ta/ofCH+YHrI6nyDKe9jVzwBkmnakjDUMD+2QUTPHy60jep+kaMm4ARKWavtfmPbQp7e+xxAHU7g==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "estree-walker": "^2.0.1",
+        "magic-string": "^0.25.7"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
     "node_modules/@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -684,6 +722,12 @@
         "@types/got": "^8",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "node_modules/@types/got": {
       "version": "8.3.5",
@@ -4765,6 +4809,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -14622,6 +14672,36 @@
         "fastq": "^1.6.0"
       }
     },
+    "@rollup/plugin-strip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-strip/-/plugin-strip-2.0.1.tgz",
+      "integrity": "sha512-+JJInHt/90Ta/ofCH+YHrI6nyDKe9jVzwBkmnakjDUMD+2QUTPHy60jep+kaMm4ARKWavtfmPbQp7e+xxAHU7g==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "estree-walker": "^2.0.1",
+        "magic-string": "^0.25.7"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -14684,6 +14764,12 @@
         "@types/got": "^8",
         "@types/node": "*"
       }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "@types/got": {
       "version": "8.3.5",
@@ -17909,6 +17995,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
     "esutils": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     ]
   },
   "devDependencies": {
+    "@rollup/plugin-strip": "^2.0.1",
     "addons-linter": "^3.7.0",
     "archiver-promise": "~1.0",
     "ava": "^3.15.0",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -326,10 +326,7 @@ async function bundleCode(browser, debug) {
 			bundleOption.input = {
 				input: ioPair.mainSourceFile,
 				plugins: debug
-					? [
-						terser(makeTerserOptions(defines)),
-						esformatter()
-					]
+					? [ terser(makeTerserOptions(defines)), esformatter() ]
 					: [
 						strip({ functions: ['debugSend', 'debugLog'] }),
 						terser(makeTerserOptions(defines)),

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -13,6 +13,7 @@ const { minify } = require('terser')
 const replace = require('replace-in-file')
 const rollup = require('rollup')
 const sharp = require('sharp')
+const strip = require('@rollup/plugin-strip')
 const terser = require('rollup-plugin-terser').terser
 
 
@@ -324,7 +325,16 @@ async function bundleCode(browser, debug) {
 
 			bundleOption.input = {
 				input: ioPair.mainSourceFile,
-				plugins: [terser(makeTerserOptions(defines)), esformatter()]
+				plugins: debug
+					? [
+						terser(makeTerserOptions(defines)),
+						esformatter()
+					]
+					: [
+						strip({ functions: ['debugSend', 'debugLog'] }),
+						terser(makeTerserOptions(defines)),
+						esformatter()
+					]
 			}
 
 			bundleOption.output = {

--- a/scripts/compare.sh
+++ b/scripts/compare.sh
@@ -17,8 +17,9 @@ echo "    <browser> <browser> d"
 echo "    <browser> d"
 echo
 echo "You may want to run the following first"
-echo "    node scripts/build.js --browser all --debug"
-echo "    node scripts/build.js --browser all"
+echo "    node scripts/build.js [--skip-linting] --skip-zipping --browser all --debug"
+echo "    node scripts/build.js [--skip-linting] --skip-zipping --browser all"
+echo
 
 if [ ! "$1" ] || [ ! "$2" ]; then
 	echo "Missing first or second arg"

--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -105,8 +105,8 @@ export default function LandmarksFinder(win, doc) {
 	let currentlySelectedElement
 
 	function updateSelectedIndexAndReturnElementInfo(index) {
-		// TODO: is this check needed? If so, isn't an index check? Where?
-		//       There are checks done in the content script too.
+		// TODO: Don't need an index check, as we trust the source. Does that
+		//       mean we also don't need the length check?
 		if (landmarks.length === 0) return
 		currentlySelectedIndex = index
 		currentlySelectedElement = landmarks[index].element

--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -105,6 +105,8 @@ export default function LandmarksFinder(win, doc) {
 	let currentlySelectedElement
 
 	function updateSelectedIndexAndReturnElementInfo(index) {
+		// TODO: is this check needed? If so, isn't an index check? Where?
+		//       There are checks done in the content script too.
 		if (landmarks.length === 0) return
 		currentlySelectedIndex = index
 		currentlySelectedElement = landmarks[index].element

--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -113,7 +113,7 @@ export default function LandmarksFinder(win, doc) {
 			role: landmarks[index].role,
 			roleDescription: landmarks[index].roleDescription,
 			label: landmarks[index].label
-			// No need to send the selector this time
+			// No need to send the selector or warnings
 		}
 	}
 

--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -191,6 +191,10 @@ export default function LandmarksFinder(win, doc) {
 			parentLandmark = element
 		}
 
+		// One just one page I've seen an error here in Chrome (91) which seems
+		// to be a bug, because only one HTMLElement was returned; not an
+		// HTMLCollection. Checking for this would cause a slowdown, so
+		// ignoring for now.
 		for (const elementChild of element.children) {
 			getLandmarks(elementChild, depth, parentLandmark)
 		}

--- a/src/assemble/gui.html
+++ b/src/assemble/gui.html
@@ -99,38 +99,49 @@
 					</details>
 				</dd>
 
-				<dt id="statsScansTerm" data-message="statsScansTerm"></dt></dt>
-			<dd>
-				<span id="scans">0</span>
-				<details class="tooltip">
-					<summary class="definition" aria-labelledby="define-statsScansTerm statsScansTerm">
-						<span id="define-statsScansTerm" data-message="statsDefine" class="visually-hidden"></span>
-					</summary>
-					<p data-message="statsScansDefinition"></p>
-				</details>
-			</dd>
+				<dt id="statsMutationScansTerm" data-message="statsMutationScansTerm"></dt>
+				<dd>
+					<span id="mutationScans">0</span>
+					<details class="tooltip">
+						<summary class="definition" aria-labelledby="define-statsMutationScansTerm statsMutationScansTerm">
+							<span id="define-statsMutationScansTerm" data-message="statsDefine" class="visually-hidden"></span>
+						</summary>
+						<p data-message="statsMutationScansDefinition"></p>
+					</details>
+				</dd>
 
-			<dt id="statsPauseTerm" data-message="statsPauseTerm"></dt>
-			<dd>
-				<span id="pause">&mdash;</span>ms
-				<details class="tooltip">
-					<summary class="definition" aria-labelledby="define-statsPauseTerm statsPauseTerm">
-						<span id="define-statsPauseTerm" data-message="statsDefine" class="visually-hidden"></span>
-					</summary>
-					<p data-message="statsPauseDefinition"></p>
-				</details>
-			</dd>
+				<dt id="statsNonMutationScansTerm" data-message="statsNonMutationScansTerm"></dt>
+				<dd>
+					<span id="nonMutationScans">0</span>
+					<details class="tooltip">
+						<summary class="definition" aria-labelledby="define-statsNonMutationScansTerm statsNonMutationScansTerm">
+							<span id="define-statsNonMutationScansTerm" data-message="statsDefine" class="visually-hidden"></span>
+						</summary>
+						<p data-message="statsNonMutationScansDefinition"></p>
+					</details>
+				</dd>
 
-			<dt id="statsDurationTerm" data-message="statsDurationTerm"></dt>
-			<dd>
-				<span id="duration">&mdash;</span>ms
-				<details class="tooltip">
-					<summary class="definition" aria-labelledby="define-statsDurationTerm statsDurationTerm">
-						<span id="define-statsDurationTerm" data-message="statsDefine" class="visually-hidden"></span>
-					</summary>
-					<p data-message="statsDurationDefinition"></p>
-				</details>
-			</dd>
+				<dt id="statsPauseTerm" data-message="statsPauseTerm"></dt>
+				<dd>
+					<span id="pause">&mdash;</span>ms
+					<details class="tooltip">
+						<summary class="definition" aria-labelledby="define-statsPauseTerm statsPauseTerm">
+							<span id="define-statsPauseTerm" data-message="statsDefine" class="visually-hidden"></span>
+						</summary>
+						<p data-message="statsPauseDefinition"></p>
+					</details>
+				</dd>
+
+				<dt id="statsDurationTerm" data-message="statsDurationTerm"></dt>
+				<dd>
+					<span id="duration">&mdash;</span>ms
+					<details class="tooltip">
+						<summary class="definition" aria-labelledby="define-statsDurationTerm statsDurationTerm">
+							<span id="define-statsDurationTerm" data-message="statsDefine" class="visually-hidden"></span>
+						</summary>
+						<p data-message="statsDurationDefinition"></p>
+					</details>
+				</dd>
 			</dl>
 			<p data-message="statsInfo"></p>
 		</details>

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -247,7 +247,7 @@
   },
 
   "statsCheckedMutationsDefinition": {
-    "message": "Mutations that Landmarks has tested to see if they are relevant."
+    "message": "Mutations that Landmarks has tested to see if they are relevant (mutations that happen during a pause in scanning are ignored)."
   },
 
   "statsMutationScansTerm": {
@@ -263,7 +263,7 @@
   },
 
   "statsNonMutationScansDefinition": {
-    "message": "Number of times the page has been scanned for landmarks for other reasons (e.g. page load/history API)."
+    "message": "Number of times the page has been scanned for landmarks for other reasons, such as: page load; use of History API; user command whilst scanning is paused due to prior mutations."
   },
 
   "statsPauseTerm": {
@@ -271,7 +271,7 @@
   },
 
   "statsPauseDefinition": {
-    "message": "Time during which subsequent changes to the page will be ignored."
+    "message": "Time window during which subsequent changes to the page will be ignored."
   },
 
   "statsDurationTerm": {

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -255,7 +255,7 @@
   },
 
   "statsMutationScansDefinition": {
-    "message": "Number of times the page has been scanned for landmarks due to mutations."
+    "message": "Number of times the page has been scanned for landmarks due to mutations. Includes scans triggered directly by mutations, as well as scans scheduled for after a pause brought on by multiple successive mutations."
   },
 
   "statsNonMutationScansTerm": {

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -250,12 +250,20 @@
     "message": "Mutations that Landmarks has tested to see if they are relevant."
   },
 
-  "statsScansTerm": {
-    "message": "Scans:"
+  "statsMutationScansTerm": {
+    "message": "Mutation scans:"
   },
 
-  "statsScansDefinition": {
-    "message": "Number of times the page has been scanned for landmarks."
+  "statsMutationScansDefinition": {
+    "message": "Number of times the page has been scanned for landmarks due to mutations."
+  },
+
+  "statsNonMutationScansTerm": {
+    "message": "Non-mutation scans:"
+  },
+
+  "statsNonMutationScansDefinition": {
+    "message": "Number of times the page has been scanned for landmarks for other reasons (e.g. page load/history API)."
   },
 
   "statsPauseTerm": {

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -223,8 +223,7 @@ browser.webNavigation.onBeforeNavigate.addListener(function(details) {
 browser.webNavigation.onCompleted.addListener(function(details) {
 	if (details.frameId > 0) return
 	setBrowserActionState(details.tabId, details.url)
-	// FIXME remove?
-	debugLog('web navigation completed')
+	debugLog('navigation completed')
 	updateGUIs(details.tabId, details.url)
 })
 
@@ -257,6 +256,7 @@ browser.webNavigation.onCompleted.addListener(function(details) {
 browser.webNavigation.onHistoryStateUpdated.addListener(function(details) {
 	if (details.frameId > 0) return
 	if (isContentScriptablePage(details.url)) {
+		debugLog(`tab ${details.tabId} history state updated`)
 		browser.tabs.sendMessage(details.tabId, { name: 'trigger-refresh' })
 	}
 })

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -27,9 +27,9 @@ function debugLog(thing, sender) {
 			console.log(`extpage: ${thing.info}`)
 		}
 	} else if (sender && sender.tab) {  // A general message from somewhere
-		console.log(`rx: ${sender.tab.id}: ${thing.name}`)
+		console.log(`bkg: rx: ${sender.tab.id}: ${thing.name}`)
 	} else {
-		console.log(`rx: ${thing.name}`)
+		console.log(`bkg: rx: ${thing.name}`)
 	}
 }
 
@@ -223,7 +223,7 @@ browser.webNavigation.onBeforeNavigate.addListener(function(details) {
 browser.webNavigation.onCompleted.addListener(function(details) {
 	if (details.frameId > 0) return
 	setBrowserActionState(details.tabId, details.url)
-	debugLog('navigation completed')
+	debugLog(`tab ${details.tabId} navigated - ${details.url}`)
 	updateGUIs(details.tabId, details.url)
 })
 
@@ -256,7 +256,7 @@ browser.webNavigation.onCompleted.addListener(function(details) {
 browser.webNavigation.onHistoryStateUpdated.addListener(function(details) {
 	if (details.frameId > 0) return
 	if (isContentScriptablePage(details.url)) {
-		debugLog(`tab ${details.tabId} history state updated`)
+		debugLog(`tab ${details.tabId} history - ${details.url}`)
 		browser.tabs.sendMessage(details.tabId, { name: 'trigger-refresh' })
 	}
 })

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -260,8 +260,8 @@ browser.webNavigation.onHistoryStateUpdated.addListener(function(details) {
 function handleTabActivation(activeTabInfo) {
 	browser.tabs.get(activeTabInfo.tabId, function(tab) {
 		if (BROWSER !== 'firefox' && browser.runtime.lastError && browser.runtime.lastError.message === 'Tabs cannot be edited right now (user may be dragging a tab).') {
-			// TODO: Remove this setTimeout hack for Chrome 91 in future
-			//       https://crbug.com/1213925
+			// FIXME: Remove this setTimeout hack for Chrome 91 in future
+			//        https://crbug.com/1213925
 			debugLog(`tab ${activeTabInfo.tabId} activated; using timeout for Chrome 91 bug`)
 			setTimeout(() => handleTabActivation(activeTabInfo), 500)
 		} else {

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -31,11 +31,11 @@ function debugLog(thing, sender) {
 		// A general message from somewhere
 		// eslint-disable-next-line no-lonely-if
 		if (sender && sender.tab) {
-			console.log(`bkg: rx: ${sender.tab.id}: ${thing.name}`)
+			console.log(`bkg: rx from ${sender.tab.id}: ${thing.name}`)
 		} else if (thing.from) {
-			console.log(`bkg: rx: devtools ${thing.from}: ${thing.name}`)
+			console.log(`bkg: rx from ${thing.from} devtools: ${thing.name}`)
 		} else {
-			console.log(`bkg: rx: (from somewhere): ${thing.name}`)
+			console.log(`bkg: rx from somewhere: ${thing.name}`)
 		}
 	}
 }

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -379,8 +379,10 @@ browser.runtime.onMessage.addListener(function(message, sender) {
 		// Messages that need to be passed through to DevTools only
 		case 'toggle-state-is':
 			browser.tabs.query({ active: true, currentWindow: true }, tabs => {
-				// FIXME: Got an "Error handling response: TypeError: Cannot
-				//        read property 'id' of undefined" in Chrome here:
+				// Note: Got an "Error handling response: TypeError: Cannot
+				//       read property 'id' of undefined" in Chrome here.
+				//       However it's not clear why this query should fail, and
+				//       there are plenty of other occurrences of it.
 				sendToDevToolsForTab(tabs[0].id, message)
 			})
 			break

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -257,17 +257,10 @@ browser.webNavigation.onHistoryStateUpdated.addListener(function(details) {
 	}
 })
 
-function handleTabActivation(activeTabInfo) {
+browser.tabs.onActivated.addListener(function(activeTabInfo) {
 	browser.tabs.get(activeTabInfo.tabId, function(tab) {
-		if (BROWSER !== 'firefox' && browser.runtime.lastError && browser.runtime.lastError.message === 'Tabs cannot be edited right now (user may be dragging a tab).') {
-			// FIXME: Remove this setTimeout hack for Chrome 91 in future
-			//        https://crbug.com/1213925
-			debugLog(`tab ${activeTabInfo.tabId} activated; using timeout for Chrome 91 bug`)
-			setTimeout(() => handleTabActivation(activeTabInfo), 500)
-		} else {
-			debugLog(`tab ${activeTabInfo.tabId} activated - ${tab.url}`)
-			updateGUIs(tab.id, tab.url)
-		}
+		debugLog(`tab ${activeTabInfo.tabId} activated - ${tab.url}`)
+		updateGUIs(tab.id, tab.url)
 	})
 	// Note: on Firefox, if the tab hasn't started loading yet, its URL comes
 	//       back as "about:blank" which makes Landmarks think it can't run on
@@ -275,8 +268,7 @@ function handleTabActivation(activeTabInfo) {
 	//       briefly before the DOM load event causes webNavigation.onCompleted
 	//       to fire and the content script is asked for and sends back the
 	//       actual landmarks.
-}
-browser.tabs.onActivated.addListener(handleTabActivation)
+})
 
 
 //

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -129,7 +129,7 @@ browser.runtime.onConnect.addListener(function(port) {
 		case 'disconnect-checker':  // Used on Chrome and Opera
 			break
 		default:
-			throw Error(`Unkown connection type ${port.name}`)
+			throw Error(`Unkown connection type "${port.name}".`)
 	}
 })
 
@@ -172,7 +172,7 @@ function switchInterface(mode) {
 			}
 			break
 		default:
-			throw Error(`Invalid interface "${mode}" given`)
+			throw Error(`Invalid interface "${mode}" given.`)
 	}
 }
 

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -244,7 +244,7 @@ browser.webNavigation.onCompleted.addListener(function(details) {
 //       only sends a short message to the content script, I've removed the
 //       'same URL' filtering.
 //
-// TODO: Check both of the below now the messaging has been streamlined:
+// FIXME: Check both of the below now the messaging has been streamlined:
 //
 // TODO: In some circumstances (most GitHub transitions, this fires two times
 //       on Firefox and three times on Chrome. For YouTube, some transitions

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -290,7 +290,7 @@ function observeMutations() {
 
 function cancelObserverReconnectionScan() {
 	if (observerReconnectionScanTimer) {
-		debugSend('cancelling scheduled scan and reconnection')
+		debugSend('cancelling scheduled observing and scan')
 		clearTimeout(observerReconnectionScanTimer)
 		observerReconnectionScanTimer = null
 	}
@@ -305,8 +305,8 @@ function reflectPageVisibility() {
 	} else {
 		debugSend('starting reconnection timer')
 		observerReconnectionScanTimer = setTimeout(function() {
-			debugSend('scheduled scanning')
-			findLandmarks(
+			debugSend('scheduled observing and scan')
+			findLandmarksAndSend(
 				msr.incrementNonMutationScans, noop)  // it will send anyway
 			observeMutations()
 			observerReconnectionScanTimer = null

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -29,7 +29,8 @@ const noop = () => {}
 //
 
 function messageHandler(message) {
-	debugSend(`received: ${message.name}`)
+	// TODO check this is removed properly in normal builds
+	if (message.name !== 'debug') debugSend(`got: ${message.name}`)
 	switch (message.name) {
 		case 'get-landmarks':
 			// A GUI is requesting the list of landmarks on the page
@@ -156,8 +157,10 @@ function checkFocusElement(callbackReturningElementInfo) {
 }
 
 // This is stripped by the build script when not in debug mode
-function debugSend(messageName) {
-	browser.runtime.sendMessage({ name: messageName })
+function debugSend(what) {
+	// When sending from a contenet script, the tab's ID will be noted by the
+	// background script, so no need to specify a 'from' key here.
+	browser.runtime.sendMessage({ name: 'debug', info: what })
 }
 
 
@@ -276,7 +279,7 @@ function observeMutationObserver() {
 }
 
 function reflectPageVisibility() {
-	debugSend('doc hidden? ' + document.hidden)
+	debugSend((document.hidden ? 'hidden' : 'shown') + ' ' + window.location)
 	if (document.hidden) {
 		if (observerReconnectionTimer) {
 			clearTimeout(observerReconnectionTimer)

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -283,14 +283,18 @@ function reflectPageVisibility() {
 	debugSend((document.hidden ? 'hidden' : 'shown') + ' ' + window.location)
 	if (document.hidden) {
 		if (observerReconnectionTimer) {
+			debugSend('clearing reconnection timer')
 			clearTimeout(observerReconnectionTimer)
 			observerReconnectionTimer = null
 		}
+		debugSend('disconnecting from observer')
 		observer.disconnect()
 	} else {
 		// The user may be switching rapidly through tabs, so we have a grace
 		// period before reconnecting to the observer.
+		debugSend('starting reconnection timer')
 		observerReconnectionTimer = setTimeout(function() {
+			debugSend('starting to observe')
 			observeMutationObserver()
 			observerReconnectionTimer = null
 		}, observerReconnectionGrace)
@@ -325,6 +329,7 @@ function bootstrap() {
 	}
 
 	document.addEventListener('visibilitychange', reflectPageVisibility, false)
+	// TODO: On Firefox, DevTools will never be open on startup - check others.
 	browser.runtime.sendMessage({ name: 'get-devtools-state' })
 	debugSend('booted')
 }

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -1,5 +1,5 @@
-// FIXME: when reconnecting to the observer, do we scan?
-// FIXME: how to ensure scan on page startup (have set pauseHandler to 0 now; is that going to cause more redundant scans?)
+// FIXME: do we need to ensure scan on page startup?
+// FIXME: need to store when the last scan was, not tie to pauseHandler
 import './compatibility'
 import LandmarksFinderStandard from './landmarksFinderStandard'
 import LandmarksFinderDeveloper from './landmarksFinderDeveloper'
@@ -18,7 +18,6 @@ const elementFocuser = new ElementFocuser(document, borderDrawer)
 const msr = new MutationStatsReporter()
 const pauseHandler = new PauseHandler(msr.setPauseTime)
 
-// FIXME: outOfDateTime seems to couple content script and pH implementation
 const outOfDateTime = 2e3              // consider landmarks stale after this
 const observerReconnectionGrace = 1e3  // wait after page becomes visible again
 let observer = null
@@ -273,6 +272,7 @@ function observeMutationObserverAndFindLandmarks() {
 	msr.sendMutationUpdate()
 }
 
+// FIXME should we NOT scan for landmarks here because when the navigation is completed, history state updated or tab activated, the background script will ask for them anyway?
 function reflectPageVisibility() {
 	debugSend('doc hidden? ' + document.hidden)
 	if (document.hidden) {
@@ -284,10 +284,6 @@ function reflectPageVisibility() {
 	} else {
 		// The user may be switching rapidly through tabs, so we have a grace
 		// period before reconnecting to the observer.
-		// FIXME: Use _this_ instead of background script onActivated check?
-		// FIXME: what about non-scriptable pages?
-		// FIXME: how about just not finding landmarks immediately here?
-		// FIXME: need to store when last landmarks were scanned, not tie to pauseHandler
 		observerReconnectionTimer = setTimeout(function() {
 			observeMutationObserverAndFindLandmarks()
 			observerReconnectionTimer = null

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -1,4 +1,5 @@
-// FIXME: need to store when the last scan was, not tie to pauseHandler
+// FIXME: need to store whether we're awaiting a scheduled scan? or does isPaused already handle this?
+// FIXME: send only number of landmarks after a mutation?
 import './compatibility'
 import LandmarksFinderStandard from './landmarksFinderStandard'
 import LandmarksFinderDeveloper from './landmarksFinderDeveloper'
@@ -314,11 +315,15 @@ function bootstrap() {
 		msr.incrementNonMutationScans,
 		noop) // it already calls the send function
 
+	debugSend('creating observer')
 	createMutationObserver()
-	observeMutationObserver()
-	debugSend('started observing for the first time')
+	if (!document.hidden) {
+		observeMutationObserver()
+		debugSend('visible: started observing for first time')
+	} else {
+		debugSend('hidden: not starting to observe')
+	}
 
-	reflectPageVisibility()
 	document.addEventListener('visibilitychange', reflectPageVisibility, false)
 	browser.runtime.sendMessage({ name: 'get-devtools-state' })
 	debugSend('booted')

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -1,6 +1,6 @@
-// FIXME: need to store whether we're awaiting a scheduled scan? or does
-//        isPaused already handle this?
 // FIXME: send only number of landmarks after a mutation?
+// FIXME: we _have_ to get the devtools-state message, so why not only start
+//        observing and scanning after that?
 import './compatibility'
 import LandmarksFinderStandard from './landmarksFinderStandard'
 import LandmarksFinderDeveloper from './landmarksFinderDeveloper'
@@ -126,13 +126,13 @@ function messageHandler(message) {
 
 function checkAndUpdateOutdatedResults() {
 	if (pauseHandler.isPaused()) {
-		debugSend('paused - re-finding landmarks')
+		debugSend('out-of-date: re-finding landmarks')
 		findLandmarksAndSend(
 			msr.incrementNonMutationScans,
 			noop)  // it already calls the send function
 		return true
 	}
-	debugSend('not paused - landmarks are up-to-date')
+	debugSend('landmarks are up-to-date')
 	return false
 }
 
@@ -150,7 +150,6 @@ function checkFocusElement(callbackReturningElementInfo) {
 	}
 }
 
-// This is stripped by the build script when not in debug mode
 function debugSend(what) {
 	// When sending from a contenet script, the tab's ID will be noted by the
 	// background script, so no need to specify a 'from' key here.

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -103,7 +103,8 @@ function messageHandler(message) {
 					debugSend('change scanner to dev')
 					landmarksFinder = landmarksFinderDeveloper
 				} else {
-					throw new Error('Was already dev scanner')
+					// TODO: Remove eventually
+					console.error('Landmarks: already using dev scanner')
 				}
 				msr.beVerbose()
 			} else {
@@ -111,7 +112,8 @@ function messageHandler(message) {
 					debugSend('change scanner to standard')
 					landmarksFinder = landmarksFinderStandard
 				} else {
-					throw new Error('Was already standard scanner')
+					// TODO: Remove eventually
+					console.error('Landmarks: already using standard scanner')
 				}
 				msr.beQuiet()
 			}

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -1,6 +1,6 @@
-// FIXME: send only number of landmarks after a mutation?
-// FIXME: we _have_ to get the devtools-state message, so why not only start
-//        observing and scanning after that?
+// TODO: we _have_ to get the devtools-state message, so why not only start
+//       observing and scanning after that? Always checking state vs. not
+//       wasting a scan whe the DevTools are already open.
 import './compatibility'
 import LandmarksFinderStandard from './landmarksFinderStandard'
 import LandmarksFinderDeveloper from './landmarksFinderDeveloper'

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -99,7 +99,7 @@ function messageHandler(message) {
 			elementFocuser.clear()
 			borderDrawer.removeAllBorders()
 			findLandmarksAndSend(
-				// TODO: this willl send the non-mutation message twice
+				// FIXME: this willl send the non-mutation message twice
 				msr.incrementNonMutationScans, msr.sendAllUpdates)
 			break
 		case 'devtools-state':
@@ -108,8 +108,6 @@ function messageHandler(message) {
 					debugSend('change scanner to dev')
 					landmarksFinder = landmarksFinderDeveloper
 					findLandmarks(noop, noop)
-				} else {
-					debugSend('scanner was already dev')
 				}
 				msr.beVerbose()
 			} else {
@@ -117,8 +115,6 @@ function messageHandler(message) {
 					debugSend('change scanner to standard')
 					landmarksFinder = landmarksFinderStandard
 					findLandmarks(noop, noop)
-				} else {
-					debugSend('scanner was already standard')
 				}
 				msr.beQuiet()
 			}
@@ -283,18 +279,14 @@ function reflectPageVisibility() {
 	debugSend((document.hidden ? 'hidden' : 'shown') + ' ' + window.location)
 	if (document.hidden) {
 		if (observerReconnectionTimer) {
-			debugSend('clearing reconnection timer')
 			clearTimeout(observerReconnectionTimer)
 			observerReconnectionTimer = null
 		}
-		debugSend('disconnecting from observer')
 		observer.disconnect()
 	} else {
 		// The user may be switching rapidly through tabs, so we have a grace
 		// period before reconnecting to the observer.
-		debugSend('starting reconnection timer')
 		observerReconnectionTimer = setTimeout(function() {
-			debugSend('starting to observe')
 			observeMutationObserver()
 			observerReconnectionTimer = null
 		}, observerReconnectionGrace)
@@ -314,28 +306,18 @@ function bootstrap() {
 			})
 	}
 
-	debugSend('initial scan')
-	findLandmarks(
-		msr.incrementNonMutationScans,
-		noop) // it already calls the send function
-
-	debugSend('creating observer')
+	findLandmarks(msr.incrementNonMutationScans, noop)  // it will send anyway
 	createMutationObserver()
 
-	// On browser load (i.e. if we are currently invisible) DevTools will never
-	// count as being open.
+	// On browser load (i.e. if we are currently invisible) there's no need to
+	// connect to the observer, and DevTools will never register as being open.
 	if (!document.hidden) {
 		observeMutationObserver()
-		debugSend('visible: started observing for first time')
-		debugSend('visible: asking about devtools')
 		browser.runtime.sendMessage({ name: 'get-devtools-state' })
-	} else {
-		debugSend('hidden: not starting to observe')
-		debugSend('hidden: not asking about devtools')
 	}
 
 	document.addEventListener('visibilitychange', reflectPageVisibility, false)
-	debugSend('booted')
+	debugSend(`booted - ${window.location}`)
 }
 
 bootstrap()

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -266,13 +266,6 @@ function observeMutationObserver() {
 	})
 }
 
-function observeMutationObserverAndFindLandmarks() {
-	observeMutationObserver()
-	findLandmarksAndUpdateExtension()
-	msr.sendMutationUpdate()
-}
-
-// FIXME should we NOT scan for landmarks here because when the navigation is completed, history state updated or tab activated, the background script will ask for them anyway?
 function reflectPageVisibility() {
 	debugSend('doc hidden? ' + document.hidden)
 	if (document.hidden) {
@@ -285,7 +278,7 @@ function reflectPageVisibility() {
 		// The user may be switching rapidly through tabs, so we have a grace
 		// period before reconnecting to the observer.
 		observerReconnectionTimer = setTimeout(function() {
-			observeMutationObserverAndFindLandmarks()
+			observeMutationObserver()
 			observerReconnectionTimer = null
 		}, observerReconnectionGrace)
 	}

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -28,8 +28,7 @@ let observer = null
 //
 
 function messageHandler(message) {
-	// TODO check this is removed properly in normal builds
-	if (message.name !== 'debug') debugSend(`rx: ${message.name}`)
+	if (DEBUG && message.name !== 'debug') debugSend(`rx: ${message.name}`)
 	switch (message.name) {
 		case 'get-landmarks':
 			// A GUI is requesting the list of landmarks on the page

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -31,7 +31,7 @@ function messageHandler(message) {
 	if (DEBUG && message.name !== 'debug') debugSend(`rx: ${message.name}`)
 	switch (message.name) {
 		case 'get-landmarks':
-			// TODO: investigate this
+			// FIXME: investigate this
 			if (landmarksFinder === null) {
 				console.error('landmarksFinder is null - ' + window.location)
 				debugSend('landmarksFinder is null')

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -20,6 +20,7 @@ const observerReconnectionGrace = 2e3  // wait after page becomes visible again
 let observerReconnectionScanTimer = null
 let observer = null
 let landmarksFinder = null
+let haveScannedForLandmarks = false
 
 
 //
@@ -96,6 +97,7 @@ function messageHandler(message) {
 			findLandmarksAndSend(
 				// TODO: this willl send the non-mutation message twice
 				msr.incrementNonMutationScans, msr.sendAllUpdates)
+			// haveScannedForLandmarks will be set to true now anyway
 			break
 		case 'devtools-state':
 			if (message.state === 'open') {
@@ -132,8 +134,8 @@ function messageHandler(message) {
 
 function doUpdateOutdatedResults() {
 	let outOfDate = false
-	if (observerReconnectionScanTimer !== null) {
-		debugSend('out-of-date: waiting to start observing')
+	if (observerReconnectionScanTimer !== null && !haveScannedForLandmarks) {
+		debugSend('out-of-date: no scan yet + waiting to observe')
 		cancelObserverReconnectionScan()
 		observeMutations()
 		outOfDate = true
@@ -190,6 +192,7 @@ function findLandmarks(counterIncrementFunction, updateSendFunction) {
 
 	const start = performance.now()
 	landmarksFinder.find()
+	if (!haveScannedForLandmarks) haveScannedForLandmarks = true
 	msr.setLastScanDuration(performance.now() - start)
 
 	counterIncrementFunction()

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -300,6 +300,7 @@ function bootstrap() {
 	createMutationObserver()
 	observeMutationObserver()
 	debugSend('started observing for the first time')
+	reflectPageVisibility()
 	document.addEventListener('visibilitychange', reflectPageVisibility, false)
 	browser.runtime.sendMessage({ name: 'get-devtools-state' })
 	debugSend('booted')

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -33,7 +33,7 @@ function messageHandler(message) {
 		case 'get-landmarks':
 			// TODO: investigate this
 			if (landmarksFinder === null) {
-				console.error('landmarksFinder is null')
+				console.error('landmarksFinder is null - ' + window.location)
 				debugSend('landmarksFinder is null')
 			}
 			// A GUI is requesting the list of landmarks on the page
@@ -111,7 +111,7 @@ function messageHandler(message) {
 					landmarksFinder = landmarksFinderDeveloper
 				} else {
 					// TODO: Remove eventually
-					console.error('Landmarks: already using dev scanner')
+					console.error('Landmarks: already using dev scanner - ' + window.location)
 				}
 				msr.beVerbose()
 			} else {
@@ -120,7 +120,7 @@ function messageHandler(message) {
 					landmarksFinder = landmarksFinderStandard
 				} else {
 					// TODO: Remove eventually
-					console.error('Landmarks: already using standard scanner')
+					console.error('Landmarks: already using standard scanner - ' + window.location)
 				}
 				msr.beQuiet()
 			}

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -106,23 +106,13 @@ function messageHandler(message) {
 			break
 		case 'devtools-state':
 			if (message.state === 'open') {
-				if (landmarksFinder !== landmarksFinderDeveloper) {
-					debugSend('change scanner to dev')
-					landmarksFinder = landmarksFinderDeveloper
-				} else {
-					// TODO: Remove eventually
-					console.error('Landmarks: already using dev scanner - ' + window.location)
-				}
+				changeScannerTo(landmarksFinderDeveloper, 'developer')
 				msr.beVerbose()
-			} else {
-				if (landmarksFinder !== landmarksFinderStandard) {
-					debugSend('change scanner to standard')
-					landmarksFinder = landmarksFinderStandard
-				} else {
-					// TODO: Remove eventually
-					console.error('Landmarks: already using standard scanner - ' + window.location)
-				}
+			} else if (message.state === 'closed') {
+				changeScannerTo(landmarksFinderStandard, 'standard')
 				msr.beQuiet()
+			} else {
+				throw Error(`Invalid DevTools state "${message.state}".`)
 			}
 			if (!document.hidden) {
 				debugSend('doc visible; also scanning')
@@ -170,6 +160,17 @@ function guiCheckThereAreLandmarks() {
 function guiCheckFocusElement(callbackReturningElementInfo) {
 	if (guiCheckThereAreLandmarks()) {
 		elementFocuser.focusElement(callbackReturningElementInfo())
+	}
+}
+
+function changeScannerTo(scanner, name) {
+	if (landmarksFinder !== scanner) {
+		debugSend(`change scanner to ${name}`)
+		landmarksFinder = scanner
+	} else {
+		// TODO: Remove eventually
+		console.error(`Landmarks: already using ${name} scanner - `
+			+ window.location)
 	}
 }
 

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -308,7 +308,7 @@ function reflectPageVisibility() {
 	} else {
 		debugSend('starting reconnection timer')
 		observerReconnectionScanTimer = setTimeout(function() {
-			debugSend('scheduled observing and scan')
+			debugSend('performing scheduled observing and scan')
 			findLandmarksAndSend(
 				msr.incrementNonMutationScans, noop)  // it will send anyway
 			observeMutations()

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -31,6 +31,11 @@ function messageHandler(message) {
 	if (DEBUG && message.name !== 'debug') debugSend(`rx: ${message.name}`)
 	switch (message.name) {
 		case 'get-landmarks':
+			// TODO: investigate this
+			if (landmarksFinder === null) {
+				console.error('landmarksFinder is null')
+				debugSend('landmarksFinder is null')
+			}
 			// A GUI is requesting the list of landmarks on the page
 			if (!doUpdateOutdatedResults()) sendLandmarks()
 			break

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -321,16 +321,20 @@ function bootstrap() {
 
 	debugSend('creating observer')
 	createMutationObserver()
+
+	// On browser load (i.e. if we are currently invisible) DevTools will never
+	// count as being open.
 	if (!document.hidden) {
 		observeMutationObserver()
 		debugSend('visible: started observing for first time')
+		debugSend('visible: asking about devtools')
+		browser.runtime.sendMessage({ name: 'get-devtools-state' })
 	} else {
 		debugSend('hidden: not starting to observe')
+		debugSend('hidden: not asking about devtools')
 	}
 
 	document.addEventListener('visibilitychange', reflectPageVisibility, false)
-	// TODO: On Firefox, DevTools will never be open on startup - check others.
-	browser.runtime.sendMessage({ name: 'get-devtools-state' })
 	debugSend('booted')
 }
 

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -298,16 +298,9 @@ function bootstrap() {
 			})
 	}
 
-	// At the start, the ElementFocuser is always managing borders
-	// TODO: Background script will ask for this after webNavigation
-	// browser.runtime.sendMessage({ name: 'toggle-state-is', data: 'selected' })
-
 	createMutationObserver()
-	debugSend('content-script-observing')
-	// TODO: Background script will ask for this after webNavigation
-	// observeMutationObserverAndFindLandmarks()
 	observeMutationObserver()
-
+	debugSend('content-script-observing')
 	document.addEventListener('visibilitychange', reflectPageVisibility, false)
 	browser.runtime.sendMessage({ name: 'get-devtools-state' })
 	debugSend('content-script-booted')

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -268,7 +268,7 @@ function reflectInterfaceChange(ui) {
 					case 'popup': showNote('note-ui')
 						break
 					default:
-						throw Error(`Unexpected interface type "${ui}"`)
+						throw Error(`Unexpected interface type "${ui}".`)
 				}
 			}
 		})
@@ -376,7 +376,7 @@ function handleToggleStateMessage(state) {
 			box.checked = true
 			break
 		default:
-			throw Error(`Unexpected toggle state ${state} given.`)
+			throw Error(`Unexpected toggle state "${state}" given.`)
 	}
 }
 

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -29,7 +29,6 @@ const _updateNote = {
 	'dismissedUpdate': {
 		id: 'note-update',
 		cta: function() {
-			// FIXME DRY
 			browser.runtime.sendMessage({ name: 'open-help' })
 			if (INTERFACE === 'popup') window.close()
 		}
@@ -118,11 +117,11 @@ function makeLandmarksTree(landmarks, container) {
 		if (INTERFACE === 'devtools') {
 			addInspectButton(item, landmark)
 
-			// FIXME: issue?
-			// TODO: When the content script first starts, it assumes that
-			//       DevTools aren't open. The background script will request a
-			//       GUI update and whilst unlikely, this might happen before
-			//       the content script has learnt that DevTools are open.
+			// TODO: come back to this check; can we make it not needed?
+			// When the content script first starts, it assumes that DevTools
+			// aren't open. The background script will request a GUI update and
+			// whilst unlikely, this might happen before the content script has
+			// learnt that DevTools are open.
 			if (landmark.hasOwnProperty('warnings')) {
 				if (landmark.warnings.length > 0) {
 					addElementWarnings(item, landmark, landmark.warnings)
@@ -329,7 +328,7 @@ function makeEventHandlers(linkName) {
 	})
 }
 
-// TODO this leaves an anonymous code block in the devtools script
+// TODO: this leaves an anonymous code block in the devtools script
 function send(message) {
 	if (INTERFACE === 'devtools') {
 		const messageWithTabId = Object.assign({}, message, {
@@ -343,7 +342,6 @@ function send(message) {
 	}
 }
 
-// This is stripped by the build script when not in debug mode
 function debugSend(what) {
 	const message = { name: 'debug', info: what }
 	if (INTERFACE === 'devtools') {
@@ -433,7 +431,6 @@ function startupPopupOrSidebar() {
 	makeEventHandlers('help')
 	makeEventHandlers('settings')
 
-	// FIXME: needed any more?
 	// The message could be coming from any content script or other GUI, so
 	// it needs to be filtered. (The background script filters out messages
 	// for the DevTools panel.)

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -118,15 +118,16 @@ function makeLandmarksTree(landmarks, container) {
 		if (INTERFACE === 'devtools') {
 			addInspectButton(item, landmark)
 
-			// NOTE: When the content script first starts, it assumes that
-			//       DevTools aren't open.
-			// TODO: fix this so it does what's apt
+			// TODO: When the content script first starts, it assumes that
+			//       DevTools aren't open. The background script will request a
+			//       GUI update and whilst unlikely, this might happen before
+			//       the content script has learnt that DevTools are open.
 			if (landmark.hasOwnProperty('warnings')) {
 				if (landmark.warnings.length > 0) {
 					addElementWarnings(item, landmark, landmark.warnings)
 				}
 			} else {
-				send({ name: 'x-no-warnings-for-' + landmark.role })
+				debugSend('no-warnings-for-' + landmark.role)
 			}
 		}
 
@@ -341,11 +342,16 @@ function send(message) {
 	}
 }
 
+// This is stripped by the build script when not in debug mode
+function debugSend(messageName) {
+	send({ name: messageName })
+}
+
 function messageHandlerCore(message) {
 	if (message.name === 'landmarks') {
 		handleLandmarksMessage(message.data)
 		if (INTERFACE === 'devtools') {
-			send({ name: 'x-got-landmarks-sending-get-page-warnings' })
+			debugSend('got-landmarks-sending-get-page-warnings')
 			send({ name: 'get-page-warnings' })
 		}
 	} else if (message.name === 'toggle-state-is') {
@@ -456,7 +462,7 @@ function startupPopupOrSidebar() {
 function main() {
 	if (INTERFACE === 'devtools') {
 		startupDevTools()
-		send({ name: 'x-devtools-startup' })
+		debugSend('devtools-startup')
 	} else {
 		startupPopupOrSidebar()
 	}

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -347,7 +347,7 @@ function send(message) {
 function debugSend(what) {
 	const message = { name: 'debug', info: what }
 	if (INTERFACE === 'devtools') {
-		message.from = browser.devtools.inspectedWindow.tabId + '-devtools'
+		message.from = `devtools ${browser.devtools.inspectedWindow.tabId}`
 		port.postMessage(message)
 	} else {
 		message.from = INTERFACE

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -118,6 +118,7 @@ function makeLandmarksTree(landmarks, container) {
 		if (INTERFACE === 'devtools') {
 			addInspectButton(item, landmark)
 
+			// FIXME: issue?
 			// TODO: When the content script first starts, it assumes that
 			//       DevTools aren't open. The background script will request a
 			//       GUI update and whilst unlikely, this might happen before

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -358,9 +358,7 @@ function debugSend(what) {
 function messageHandlerCore(message) {
 	if (message.name === 'landmarks') {
 		handleLandmarksMessage(message.data)
-		if (INTERFACE === 'devtools') {
-			send({ name: 'get-page-warnings' })
-		}
+		if (INTERFACE === 'devtools') send({ name: 'get-page-warnings' })
 	} else if (message.name === 'toggle-state-is') {
 		handleToggleStateMessage(message.data)
 	} else if (INTERFACE === 'devtools' && message.name === 'mutation-info') {
@@ -435,7 +433,7 @@ function startupPopupOrSidebar() {
 	makeEventHandlers('help')
 	makeEventHandlers('settings')
 
-	// TODO: needed any more?
+	// FIXME: needed any more?
 	// The message could be coming from any content script or other GUI, so
 	// it needs to be filtered. (The background script filters out messages
 	// for the DevTools panel.)

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -127,7 +127,7 @@ function makeLandmarksTree(landmarks, container) {
 					addElementWarnings(item, landmark, landmark.warnings)
 				}
 			} else {
-				debugSend('no-warnings-for-' + landmark.role)
+				debugSend('no warnings for ' + landmark.role)
 			}
 		}
 
@@ -344,14 +344,13 @@ function send(message) {
 
 // This is stripped by the build script when not in debug mode
 function debugSend(messageName) {
-	send({ name: messageName })
+	send({ name: INTERFACE + ': ' + messageName })
 }
 
 function messageHandlerCore(message) {
 	if (message.name === 'landmarks') {
 		handleLandmarksMessage(message.data)
 		if (INTERFACE === 'devtools') {
-			debugSend('got-landmarks-sending-get-page-warnings')
 			send({ name: 'get-page-warnings' })
 		}
 	} else if (message.name === 'toggle-state-is') {
@@ -462,7 +461,6 @@ function startupPopupOrSidebar() {
 function main() {
 	if (INTERFACE === 'devtools') {
 		startupDevTools()
-		debugSend('devtools-startup')
 	} else {
 		startupPopupOrSidebar()
 	}
@@ -472,6 +470,7 @@ function main() {
 	})
 
 	translate()
+	debugSend('started up')
 }
 
 main()

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -343,8 +343,15 @@ function send(message) {
 }
 
 // This is stripped by the build script when not in debug mode
-function debugSend(messageName) {
-	send({ name: INTERFACE + ': ' + messageName })
+function debugSend(what) {
+	const message = { name: 'debug', info: what }
+	if (INTERFACE === 'devtools') {
+		message.from = browser.devtools.inspectedWindow.tabId + '-devtools'
+		port.postMessage(message)
+	} else {
+		message.from = INTERFACE
+		browser.runtime.sendMessage(message)
+	}
 }
 
 function messageHandlerCore(message) {
@@ -427,6 +434,7 @@ function startupPopupOrSidebar() {
 	makeEventHandlers('help')
 	makeEventHandlers('settings')
 
+	// TODO: needed any more?
 	// The message could be coming from any content script or other GUI, so
 	// it needs to be filtered. (The background script filters out messages
 	// for the DevTools panel.)

--- a/src/code/compatibility.js
+++ b/src/code/compatibility.js
@@ -7,5 +7,5 @@ switch (BROWSER) {
 		window.browser = window.chrome
 		break
 	default:
-		throw Error(`Landmarks: invalid browser ${BROWSER} given.`)
+		throw Error(`Invalid browser "${BROWSER}" given.`)
 }

--- a/src/code/contentScriptInjector.js
+++ b/src/code/contentScriptInjector.js
@@ -1,8 +1,9 @@
 import { isContentInjectablePage } from './isContent'
+import { withAllTabs } from './withTabs'
 
 const contentScriptInjector = BROWSER === 'firefox' ? null : function() {
 	// Inject content script manually
-	browser.tabs.query({}, function(tabs) {
+	withAllTabs(function(tabs) {
 		for (const i in tabs) {
 			if (isContentInjectablePage(tabs[i].url)) {
 				browser.tabs.executeScript(tabs[i].id, { file: 'content.js' },

--- a/src/code/keyboardShortcutTableMaker.js
+++ b/src/code/keyboardShortcutTableMaker.js
@@ -44,7 +44,7 @@ function makeHTML(structure, root) {
 				}
 				break
 			default:
-				throw Error(`Unexpected structure key ${key} encountered.`)
+				throw Error(`Unexpected structure key "${key}" encountered.`)
 		}
 	}
 

--- a/src/code/mutationStatsReporter.js
+++ b/src/code/mutationStatsReporter.js
@@ -1,7 +1,9 @@
+// TODO: make this like the mutation observer—disconnect when DevTools isn't open?
 export default function MutationStatsReporter() {
 	let totalMutations = 0
 	let checkedMutations = 0
 	let mutationScans = 0
+	let nonMutationScans = 0
 	let pauseTime = null
 	let lastScanDuration = null
 
@@ -16,6 +18,7 @@ export default function MutationStatsReporter() {
 		totalMutations = 0
 		checkedMutations = 0
 		mutationScans = 0
+		nonMutationScans = 0
 		pauseTime = null
 		lastScanDuration = null
 	}
@@ -41,6 +44,11 @@ export default function MutationStatsReporter() {
 		mutationScans += 1
 	}
 
+	this.incrementNonMutationScans = function() {
+		nonMutationScans += 1
+		if (!quiet) _sendNonMutationScansUpdate()
+	}
+
 	this.setPauseTime = function(time) {
 		pauseTime = time
 		if (!quiet) _sendPauseTimeUpdate()
@@ -50,6 +58,11 @@ export default function MutationStatsReporter() {
 		lastScanDuration = Math.round(duration)  // Chrome is precise
 		if (!quiet) _sendDurationUpdate()
 	}
+
+	// Only these two public send methods are exposed because the mutation info
+	// update consists of three things that are sent after each mutation, check
+	// and possible scan. Also quite high-traffic perhaps, so cutting down on
+	// the times this info is sent is important.
 
 	this.sendMutationUpdate = function() {
 		if (!quiet) _sendMutationUpdate()
@@ -69,7 +82,15 @@ export default function MutationStatsReporter() {
 			name: 'mutation-info', data: {
 				'mutations': totalMutations,
 				'checks': checkedMutations,
-				'scans': mutationScans
+				'mutationScans': mutationScans
+			}
+		})
+	}
+
+	function _sendNonMutationScansUpdate() {
+		browser.runtime.sendMessage({
+			name: 'mutation-info', data: {
+				'nonMutationScans': nonMutationScans
 			}
 		})
 	}
@@ -92,6 +113,7 @@ export default function MutationStatsReporter() {
 
 	function _sendAllUpdates() {
 		_sendMutationUpdate()
+		_sendNonMutationScansUpdate()
 		_sendPauseTimeUpdate()
 		_sendDurationUpdate()
 	}

--- a/src/code/mutationStatsReporter.js
+++ b/src/code/mutationStatsReporter.js
@@ -1,4 +1,5 @@
-// TODO: make this like the mutation observer—disconnect when DevTools isn't open?
+// TODO: make this like the mutation observer—disconnect when DevTools isn't
+//       open? (Would need to manage expectations in that case.)
 export default function MutationStatsReporter() {
 	let totalMutations = 0
 	let checkedMutations = 0

--- a/src/code/pauseHandler.js
+++ b/src/code/pauseHandler.js
@@ -83,7 +83,7 @@ export default function PauseHandler(pauseTimeHook) {
 		}
 	}
 
-	this.getPauseTime = function() {
-		return pause
+	this.isPaused = function() {
+		return decreasePauseTimeout !== null
 	}
 }

--- a/src/code/pauseHandler.js
+++ b/src/code/pauseHandler.js
@@ -1,7 +1,3 @@
-// FIXME: Are landmarks up-to-date at end of pause really? How does this tie in
-//        with the scheduled task?
-// FIXME: if we come to run the scheduled task but are still paused, shouldn't
-//        we drop it? (If the user asks for landmarks they'll be updated.)
 export default function PauseHandler(pauseTimeHook) {
 	//
 	// Constants
@@ -97,7 +93,7 @@ export default function PauseHandler(pauseTimeHook) {
 	}
 
 	this.isPaused = function() {
-		return decreasePauseTimeout !== null
+		return pause > minPause
 	}
 
 	this.reset = function() {

--- a/src/code/pauseHandler.js
+++ b/src/code/pauseHandler.js
@@ -1,3 +1,7 @@
+// FIXME: Are landmarks up-to-date at end of pause really? How does this tie in
+//        with the scheduled task?
+// FIXME: if we come to run the scheduled task but are still paused, shouldn't
+//        we drop it? (If the user asks for landmarks they'll be updated.)
 export default function PauseHandler(pauseTimeHook) {
 	//
 	// Constants
@@ -16,6 +20,7 @@ export default function PauseHandler(pauseTimeHook) {
 
 	let pause = minPause
 	let lastEvent = Date.now()
+	let scheduledTaskTimeout = null
 	let decreasePauseTimeout = null
 	let haveIncreasedPauseAndScheduledTask = false
 	pauseTimeHook(pause)
@@ -51,11 +56,19 @@ export default function PauseHandler(pauseTimeHook) {
 		pauseTimeHook(pause)
 	}
 
-	function stopDecreasingPause() {
-		if (decreasePauseTimeout) {
-			clearTimeout(decreasePauseTimeout)
-			decreasePauseTimeout = null
+	function ceaseTimeout(timeout) {
+		if (timeout) {
+			clearTimeout(timeout)
+			timeout = null
 		}
+	}
+
+	function stopDecreasingPause() {
+		ceaseTimeout(decreasePauseTimeout)
+	}
+
+	function cancelScheduledTask() {
+		ceaseTimeout(scheduledTaskTimeout)
 	}
 
 
@@ -63,7 +76,7 @@ export default function PauseHandler(pauseTimeHook) {
 	// Public API
 	//
 
-	// TODO would this be more efficient if tasks specified at init?
+	// TODO: would this be more efficient if tasks specified at init?
 	this.run = function(ignoreCheck, guardedTask, scheduledTask) {
 		if (ignoreCheck()) return
 
@@ -74,7 +87,7 @@ export default function PauseHandler(pauseTimeHook) {
 		} else if (!haveIncreasedPauseAndScheduledTask) {
 			increasePause()
 			if (DEBUG) console.timeStamp(`Scheduling task in: ${pause}`)
-			setTimeout(() => {
+			scheduledTaskTimeout = setTimeout(() => {
 				scheduledTask()
 				decreasePause()
 				haveIncreasedPauseAndScheduledTask = false
@@ -85,5 +98,11 @@ export default function PauseHandler(pauseTimeHook) {
 
 	this.isPaused = function() {
 		return decreasePauseTimeout !== null
+	}
+
+	this.reset = function() {
+		cancelScheduledTask()
+		stopDecreasingPause()
+		pause = minPause
 	}
 }

--- a/src/code/withTabs.js
+++ b/src/code/withTabs.js
@@ -1,0 +1,11 @@
+export function withActiveTab(doThis) {
+	browser.tabs.query({ active: true, currentWindow: true }, tabs => {
+		doThis(tabs[0])
+	})
+}
+
+export function withAllTabs(doThis) {
+	browser.tabs.query({}, tabs => {
+		doThis(tabs)
+	})
+}


### PR DESCRIPTION
* Add debugging output to debug builds.
* Add rollup-plugin-strip to remove debugging info from production builds.
* Add a script to compare different builds (browser-debug and cross-browser).
* Clarify and update a load of comments.
* Count mutations not caused by mutations separately. (Scans scheduled after a pause caused by a mutation count as having been caused by mutations.)
* Factor out doing stuff with the active tab, or all tabs.
* Work around errors when sending messages to non-scriptable pages in Firefox and Opera (where the sidebar may be open) by checking for the error.
* Clean up background script code.
* Rename several functions in the content script to clear up what they do.
* Don't scan for landmarks on content script startup; wait until the devtools-state message is received.
* Don't scan for landmarks if the page is not visible when that message is received.
* Do scan for landmarks if we are asked and haven't scanned yet (otherwise don't).
* Fix detecting whether landmarks are out-of-date.
* Ensure that counters are correctly incremented when scanning.
* Harmonise the way errors are thrown/reported.