### PR TITLE
chore: Bump pssst dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "husky": "^7.0.1",
         "jsdom": "^16.6.0",
         "nyc": "^15.1.0",
-        "page-structural-semantics-scanner-tests": "git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#0.6.0",
+        "page-structural-semantics-scanner-tests": "git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#0.7.0",
         "puppeteer": "^10.0.0",
         "replace-in-file": "^6.2.0",
         "rollup": "^2.55.1",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
-      "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.9.tgz",
+      "integrity": "sha512-p3QjZmMGHDGdpcwEYYWu7i7oJShJvtgMjJeb0W95PPhSm++3lm8YXYOh45Y6iCN9PkZLTZ7CIX5nFrp7pw7TXw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -115,12 +115,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.8.tgz",
-      "integrity": "sha512-cYDUpvIzhBVnMzRoY1fkSEhK/HmwEVwlyULYgn/tMQYd6Obag3ylCjONle3gdErfXBW61SVTlR9QR7uWlgeIkg==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.9.tgz",
+      "integrity": "sha512-4yoHbhDYzFa0GLfCzLp5GxH7vPPMAHdZjyE7M/OajM9037zhx0rf+iNsJwp4PT0MSFpwjG7BsHEbPkBQpZ6cYA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.8",
+        "@babel/types": "^7.14.9",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -297,9 +297,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-      "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -399,9 +399,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.8.tgz",
-      "integrity": "sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.9.tgz",
+      "integrity": "sha512-RdUTOseXJ8POjjOeEBEvNMIZU/nm4yu2rufRkcibzkkg7DmQvXU8v3M4Xk9G7uuI86CDGkKcuDWgioqZm+mScQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -437,18 +437,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.8.tgz",
-      "integrity": "sha512-kexHhzCljJcFNn1KYAQ6A5wxMRzq9ebYpEDV4+WdNyr3i7O44tanbDOR/xjiG2F3sllan+LgwK+7OMk0EmydHg==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.9.tgz",
+      "integrity": "sha512-bldh6dtB49L8q9bUyB7bC20UKgU+EFDwKJylwl234Kv+ySZeMD31Xeht6URyueQ6LrRRpF2tmkfcZooZR9/e8g==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.8",
+        "@babel/generator": "^7.14.9",
         "@babel/helper-function-name": "^7.14.5",
         "@babel/helper-hoist-variables": "^7.14.5",
         "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.8",
-        "@babel/types": "^7.14.8",
+        "@babel/parser": "^7.14.9",
+        "@babel/types": "^7.14.9",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -478,12 +478,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-      "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
+      "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.8",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -784,9 +784,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.8.tgz",
-      "integrity": "sha512-VL7RZyCpfYEmbyd3/Eq5RNYhZt7yoL1JThZQ3KzimzhLya2Qa86U1ZZmioNWAAjiz99z1ED1xF9NUV2srvfVrA==",
+      "version": "16.4.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
+      "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -9319,8 +9319,8 @@
       }
     },
     "node_modules/page-structural-semantics-scanner-tests": {
-      "version": "0.6.0",
-      "resolved": "git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#5a5c348f9c03051e6be27548095f54ed41b24982",
+      "version": "0.7.0",
+      "resolved": "git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#436fc363909b51326d15e00ce4a602aec410de44",
       "dev": true,
       "license": "MIT"
     },
@@ -14227,9 +14227,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
-      "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.9.tgz",
+      "integrity": "sha512-p3QjZmMGHDGdpcwEYYWu7i7oJShJvtgMjJeb0W95PPhSm++3lm8YXYOh45Y6iCN9PkZLTZ7CIX5nFrp7pw7TXw==",
       "dev": true
     },
     "@babel/core": {
@@ -14279,12 +14279,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.8.tgz",
-      "integrity": "sha512-cYDUpvIzhBVnMzRoY1fkSEhK/HmwEVwlyULYgn/tMQYd6Obag3ylCjONle3gdErfXBW61SVTlR9QR7uWlgeIkg==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.9.tgz",
+      "integrity": "sha512-4yoHbhDYzFa0GLfCzLp5GxH7vPPMAHdZjyE7M/OajM9037zhx0rf+iNsJwp4PT0MSFpwjG7BsHEbPkBQpZ6cYA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.8",
+        "@babel/types": "^7.14.9",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -14420,9 +14420,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-      "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -14497,9 +14497,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.8.tgz",
-      "integrity": "sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.9.tgz",
+      "integrity": "sha512-RdUTOseXJ8POjjOeEBEvNMIZU/nm4yu2rufRkcibzkkg7DmQvXU8v3M4Xk9G7uuI86CDGkKcuDWgioqZm+mScQ==",
       "dev": true
     },
     "@babel/template": {
@@ -14525,18 +14525,18 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.8.tgz",
-      "integrity": "sha512-kexHhzCljJcFNn1KYAQ6A5wxMRzq9ebYpEDV4+WdNyr3i7O44tanbDOR/xjiG2F3sllan+LgwK+7OMk0EmydHg==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.9.tgz",
+      "integrity": "sha512-bldh6dtB49L8q9bUyB7bC20UKgU+EFDwKJylwl234Kv+ySZeMD31Xeht6URyueQ6LrRRpF2tmkfcZooZR9/e8g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.8",
+        "@babel/generator": "^7.14.9",
         "@babel/helper-function-name": "^7.14.5",
         "@babel/helper-hoist-variables": "^7.14.5",
         "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.8",
-        "@babel/types": "^7.14.8",
+        "@babel/parser": "^7.14.9",
+        "@babel/types": "^7.14.9",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -14559,12 +14559,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-      "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
+      "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.8",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -14809,9 +14809,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.8.tgz",
-      "integrity": "sha512-VL7RZyCpfYEmbyd3/Eq5RNYhZt7yoL1JThZQ3KzimzhLya2Qa86U1ZZmioNWAAjiz99z1ED1xF9NUV2srvfVrA==",
+      "version": "16.4.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
+      "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -21418,9 +21418,9 @@
       }
     },
     "page-structural-semantics-scanner-tests": {
-      "version": "git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#5a5c348f9c03051e6be27548095f54ed41b24982",
+      "version": "git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#436fc363909b51326d15e00ce4a602aec410de44",
       "dev": true,
-      "from": "page-structural-semantics-scanner-tests@git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#0.6.0"
+      "from": "page-structural-semantics-scanner-tests@git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#0.7.0"
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "husky": "^7.0.1",
     "jsdom": "^16.6.0",
     "nyc": "^15.1.0",
-    "page-structural-semantics-scanner-tests": "git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#0.6.0",
+    "page-structural-semantics-scanner-tests": "git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#0.7.0",
     "puppeteer": "^10.0.0",
     "replace-in-file": "^6.2.0",
     "rollup": "^2.55.1",


### PR DESCRIPTION
This includes a feature that ignores dotfiles, so I can have a tighter edit-test cycle.