### PR TITLE
fix: Ignore guessed regions with no innerText

### DIFF
--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -291,6 +291,14 @@ export default function LandmarksFinder(win, doc, useHeuristics) {
 		return true
 	}
 
+	// TODO: Check if we need this at all?
+	// Note: This only checks the element itself: it won't reflect if this
+	//       element is contained in another that _is_ visually hidden. So far
+	//       this only seems to be a problem for some OTTly-guessed landmarks,
+	//       though (heuristics aren't using this function, but there's no
+	//       point due to not considering the parents).
+	// https://stackoverflow.com/a/56692552/1485308
+	// https://stackoverflow.com/q/19669786/1485308
 	function isVisuallyHidden(element) {
 		const style = win.getComputedStyle(element)
 		if (element.hasAttribute('hidden')
@@ -418,7 +426,7 @@ export default function LandmarksFinder(win, doc, useHeuristics) {
 	}
 
 	function addGuessed(guessed, role) {
-		if (guessed) {
+		if (guessed && guessed.innerText) {
 			if (landmarks.length === 0) {
 				landmarks.push(makeLandmarkEntry(guessed, role))
 				if (role === 'main') mainElementIndices = [0]

--- a/test/heuristics/expectations/guess-navigation-with-main-some-empty.json
+++ b/test/heuristics/expectations/guess-navigation-with-main-some-empty.json
@@ -1,0 +1,23 @@
+{
+  "meta": {
+    "name": "Guess navigation regions with a main (some empty)"
+  },
+  "expected": [
+    {
+      "type": "landmark",
+      "role": "main",
+      "roleDescription": null,
+      "label": null,
+      "selector": "#content",
+      "guessed": true
+    },
+    {
+      "type": "landmark",
+      "role": "navigation",
+      "roleDescription": null,
+      "label": null,
+      "selector": "#nav-el",
+      "guessed": true
+    }
+  ]
+}

--- a/test/heuristics/fixtures/guess-navigation-with-main-some-empty.html
+++ b/test/heuristics/fixtures/guess-navigation-with-main-some-empty.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Test guessing navigation regions with a main (some empty)</title>
+</head>
+<body>
+	<h1>Test guessing navigation regions with a main (some empty)</h1>
+	<p>Some sites will use different elements at different breakpoints for example. The container itself may not be marked as invisible.</p>
+	<div id="main">
+		<!-- This has a comment -->
+	</div>
+	<div id="content">
+		This is the one.
+	</div>
+	<div class="navigation" id="nav-igation"></div>
+	<div class="navigation" id="nav-el"><p>Here it is</p></div>
+</body>
+</html>

--- a/test/testLandmarksFinder.js
+++ b/test/testLandmarksFinder.js
@@ -149,6 +149,22 @@ function testSpecificLandmarksFinder(
 	for (const check of Object.values(checks)) {
 		test(runName + ': ' + check.meta.name, t => {
 			const dom = new JSDOM(check.fixture)
+
+			// Expose jsdom's existing textContent method, tweaked, as innerText
+			// https://github.com/jsdom/jsdom/issues/1245#issuecomment-445848341
+			// https://github.com/jsdom/jsdom/issues/1245#issuecomment-584677454
+			// Plus my own tweak removing whitespace.
+			if (heuristics) {
+				global.Element = dom.window.Element
+				Object.defineProperty(global.Element.prototype, 'innerText', {
+					get() {
+						this.querySelectorAll('script,style').forEach(
+							s => s.remove())
+						return this.textContent.replace(/\s+/g, '')
+					}
+				})
+			}
+
 			const lf = new Scanner(dom.window, dom.window.document, heuristics)
 			lf.find()
 			const landmarksFinderResult = postProcesor


### PR DESCRIPTION
I noticed a site in the wild with several guessed regions, including
some spurious ones. This addresses some of the issue by ignoring any
region that's essentially empty from the user's perspective. It does not
address regions that are visually hidden, as getComputedStyle() doesn't
cover hidden parent elements. Have decided not to change that for now,
due to the expected performance hit and lack of other examples of false
positives.
