### PR TITLE
fix: Ensure update notice returns after an update

### DIFF
--- a/src/assemble/manifest.firefox.json
+++ b/src/assemble/manifest.firefox.json
@@ -27,7 +27,7 @@
     "browser_style": false
   },
 
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "ariaLandmarkNav@ibm.com",
       "strict_min_version": "73.0"


### PR DESCRIPTION
* Handle update events by flagging that the update notice isn't dismissed.
* Remove the second parameter to the call to make it simpler. This does
  mean that resetting all messages will also reset the update notice, but
  leaving that for now.
* Update manifest terminology. Not sure if this helps with the debugging, but
  Firefox does seem to treat first install like an install and subsequent
  reloads like an update now...
