### PR TITLE
fix: Reflect opera sidebar bug

### DIFF
--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -186,9 +186,14 @@ function switchInterface(mode) {
 
 if (BROWSER === 'firefox' || BROWSER === 'opera') {
 	startupCode.push(function() {
-		browser.storage.sync.get(defaultInterfaceSettings, function(items) {
-			switchInterface(items.interface)
-		})
+		// TODO: Remove when Opera bug is fixed...
+		if (BROWSER === 'opera') {
+			browser.storage.sync.set({ interface: 'popup' })
+		} else {
+			browser.storage.sync.get(defaultInterfaceSettings, function(items) {
+				switchInterface(items.interface)
+			})
+		}
 	})
 }
 

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -186,8 +186,8 @@ function switchInterface(mode) {
 
 if (BROWSER === 'firefox' || BROWSER === 'opera') {
 	startupCode.push(function() {
-		// TODO: Remove when Opera bug is fixed...
 		if (BROWSER === 'opera') {
+			// TODO: Remove when Opera bug is fixed...
 			browser.storage.sync.set({ interface: 'popup' })
 		} else {
 			browser.storage.sync.get(defaultInterfaceSettings, function(items) {

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -124,7 +124,7 @@ function main() {
 
 		if (BROWSER === 'opera') {
 			const radio = document.getElementById('radio-sidebar')
-			// radio.disabled = true
+			radio.disabled = true
 			const warning = document.createElement('p')
 			warning.textContent = 'There is a known bug with Opera that prevents the sidebar from being recognised. They are working on it.'
 			warning.className = 'warning'

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -124,7 +124,7 @@ function main() {
 
 		if (BROWSER === 'opera') {
 			const radio = document.getElementById('radio-sidebar')
-			radio.disabled = true
+			// radio.disabled = true
 			const warning = document.createElement('p')
 			warning.textContent = 'There is a known bug with Opera that prevents the sidebar from being recognised. They are working on it.'
 			warning.className = 'warning'

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -121,6 +121,16 @@ function main() {
 			name: 'interface',
 			kind: 'radio'
 		})
+
+		if (BROWSER === 'opera') {
+			const radio = document.getElementById('radio-sidebar')
+			radio.disabled = true
+			const warning = document.createElement('p')
+			warning.textContent = 'There is a known bug with Opera that prevents the sidebar from being recognised. They are working on it.'
+			warning.className = 'warning'
+			const target = radio.nextElementSibling.firstElementChild
+			target.insertAdjacentElement('afterend', warning)
+		}
 	}
 
 	updateResetDismissedMessagesButtonState()

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -123,6 +123,7 @@ function main() {
 		})
 
 		if (BROWSER === 'opera') {
+			// TODO: Remove when Opera bug is fixed...
 			const radio = document.getElementById('radio-sidebar')
 			radio.disabled = true
 			const warning = document.createElement('p')


### PR DESCRIPTION
There is a known bug that stops the sidebar part of the extension from
being recognised. The moderators told me they're working on it, but for
now this disables the sidebar on Opera, and gives a warning to users.