### PR TITLE
fix: Neater settings resetting

### DIFF
--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -89,7 +89,7 @@
   },
 
   "prefsResetAll": {
-    "message": "Reset settings to defaults"
+    "message": "Reset everything to defaults"
   },
 
   "prefsResetMessages": {

--- a/src/code/_background.js
+++ b/src/code/_background.js
@@ -411,7 +411,8 @@ if (BROWSER !== 'firefox') {
 browser.storage.onChanged.addListener(function(changes) {
 	if (BROWSER === 'firefox' || BROWSER === 'opera') {
 		if (changes.hasOwnProperty('interface')) {
-			switchInterface(changes.interface.newValue)
+			switchInterface(changes.interface.newValue
+				?? defaultInterfaceSettings.interface)
 		}
 	}
 

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -289,7 +289,8 @@ function setupNotes() {
 	browser.storage.onChanged.addListener(function(changes) {
 		if (INTERFACE === 'sidebar') {
 			if (changes.hasOwnProperty('interface')) {
-				reflectInterfaceChange(changes.interface.newValue)
+				reflectInterfaceChange(changes.interface.newValue ??
+					defaultInterfaceSettings.interface)
 			}
 		}
 

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -101,13 +101,8 @@ function dismissalStateChanged(thingChanged) {
 }
 
 function resetToDefaults() {
-	browser.storage.sync.set(defaultSettings, function() {
-		window.location.reload()
-	})
-	// Note: Can't use use .clear() as that removes everything, which would
-	//       cause problems for currently-visible borders.
-	// FIXME use restoreOptions instead?
-	// FIXME resetting to defaults after seetting to sidebar still brings up the warning message (even though it's going back to toolbar) -- this is because it reloads and persists the selection across reloads
+	browser.storage.sync.clear()
+	restoreOptions()
 }
 
 

--- a/src/code/borderDrawer.js
+++ b/src/code/borderDrawer.js
@@ -46,10 +46,12 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 		let needUpdate = false
 		if ('borderColour' in changes) {
 			borderColour = changes.borderColour.newValue
+				?? defaultBorderSettings.borderColour
 			needUpdate = true
 		}
 		if ('borderFontSize' in changes) {
 			borderFontSize = changes.borderFontSize.newValue
+				?? defaultBorderSettings.borderFontSize
 			needUpdate = true
 		}
 		if (needUpdate) {

--- a/src/code/elementFocuser.js
+++ b/src/code/elementFocuser.js
@@ -23,7 +23,8 @@ export default function ElementFocuser(doc, borderDrawer) {
 
 	browser.storage.onChanged.addListener(function(changes) {
 		if ('borderType' in changes) {
-			borderType = changes.borderType.newValue
+			borderType =
+				changes.borderType.newValue ?? defaultBorderSettings.borderType
 			borderTypeChange()
 		}
 	})


### PR DESCRIPTION
* Clear all settings (including dismissal states) when resetting.
* Update a translation string to make the new behaviour clearer.
* When reacting to storage changes relating to cached variables, cope
  with the possibility that the new value is undefined.
* Remove a no-longer-applicable FIXME.

Fixes #448