### PR TITLE
feat: Add an option to control whether heuristics are used

### DIFF
--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-prototype-builtins */
-export default function LandmarksFinder(win, doc) {
+export default function LandmarksFinder(win, doc, _testUseHeuristics) {
 	//
 	// Constants
 	//
@@ -88,7 +88,7 @@ export default function LandmarksFinder(win, doc) {
 	// and, in developer mode:
 	//   warnings [string]               -- list of warnings about this element
 
-	let useHeuristics = null
+	let useHeuristics = _testUseHeuristics  // parameter is only use by tests
 	let _pageWarnings = MODE === 'developer' ? [] : null
 	const _unlabelledRoleElements = MODE === 'developer' ? new Map() : null
 	let _visibleMainElements = MODE === 'developer' ? [] : null

--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -88,11 +88,10 @@ export default function LandmarksFinder(win, doc) {
 	// and, in developer mode:
 	//   warnings [string]               -- list of warnings about this element
 
+	let useHeuristics = null
 	let _pageWarnings = MODE === 'developer' ? [] : null
 	const _unlabelledRoleElements = MODE === 'developer' ? new Map() : null
 	let _visibleMainElements = MODE === 'developer' ? [] : null
-
-	let useHeuristics = true
 
 
 	//

--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -88,7 +88,7 @@ export default function LandmarksFinder(win, doc, _testUseHeuristics) {
 	// and, in developer mode:
 	//   warnings [string]               -- list of warnings about this element
 
-	let useHeuristics = _testUseHeuristics  // parameter is only use by tests
+	let useHeuristics = _testUseHeuristics  // parameter is only used by tests
 	let _pageWarnings = MODE === 'developer' ? [] : null
 	const _unlabelledRoleElements = MODE === 'developer' ? new Map() : null
 	let _visibleMainElements = MODE === 'developer' ? [] : null

--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -580,7 +580,10 @@ export default function LandmarksFinder(win, doc) {
 	}
 
 	this.useHeuristics = function(use) {
-		console.log('setting useHeuristics to', use)
-		useHeuristics = use
+		if (typeof use === 'boolean') {
+			useHeuristics = use
+		} else {
+			throw Error(`useHeuristics() given ${typeof use} value: ${use}`)
+		}
 	}
 }

--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-prototype-builtins */
-export default function LandmarksFinder(win, doc, useHeuristics) {
+export default function LandmarksFinder(win, doc) {
 	//
 	// Constants
 	//
@@ -91,6 +91,8 @@ export default function LandmarksFinder(win, doc, useHeuristics) {
 	let _pageWarnings = MODE === 'developer' ? [] : null
 	const _unlabelledRoleElements = MODE === 'developer' ? new Map() : null
 	let _visibleMainElements = MODE === 'developer' ? [] : null
+
+	let useHeuristics = true
 
 
 	//
@@ -575,5 +577,10 @@ export default function LandmarksFinder(win, doc, useHeuristics) {
 			return updateSelectedAndReturnElementInfo(mainElementIndex)
 		}
 		return null
+	}
+
+	this.useHeuristics = function(use) {
+		console.log('setting useHeuristics to', use)
+		useHeuristics = use
 	}
 }

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -96,12 +96,12 @@
     "message": "Border label font size (pixels):"
   },
 
-  "prefsDeveloper": {
-    "message": "Developer and accessibility auditor settings"
+  "prefsGuessLandmarks": {
+    "message": "Try to guess some landmarks if they're not provided"
   },
 
-  "prefsDeveloperDoNotGuess": {
-    "message": "Do not guess landmark regions"
+  "prefsGuessLandmarksInfo": {
+    "message": "If you're a developer or accessibility auditor, you may wish to disable this, as guessed landmarks are counted in the toolbar badge. Regardless of this setting, relevant warnings are always shown in the Landmarks DevTools side pane."
   },
 
   "prefsResetAll": {

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -72,6 +72,10 @@
     "message": "Landmarks preferences"
   },
 
+  "prefsHeadingBorder": {
+    "message": "Border and label appearance"
+  },
+
   "prefsBorderType": {
     "message": "Border type"
   },
@@ -96,12 +100,20 @@
     "message": "Border label font size (pixels):"
   },
 
+  "prefsHeadingFunctionality": {
+    "message": "Functionality"
+  },
+
   "prefsGuessLandmarks": {
     "message": "Try to guess some landmarks if they're not provided"
   },
 
   "prefsGuessLandmarksInfo": {
     "message": "If you're a developer or accessibility auditor, you may wish to disable this, as guessed landmarks are counted in the toolbar badge. Regardless of this setting, relevant warnings are always shown in the Landmarks DevTools side pane."
+  },
+
+  "prefsHeadingReset": {
+    "message": "Resetting stuff"
   },
 
   "prefsResetAll": {

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -96,6 +96,14 @@
     "message": "Border label font size (pixels):"
   },
 
+  "prefsDeveloper": {
+    "message": "Developer and accessibility auditor settings"
+  },
+
+  "prefsDeveloperDoNotGuess": {
+    "message": "Do not guess landmark regions"
+  },
+
   "prefsResetAll": {
     "message": "Reset everything to defaults"
   },

--- a/src/assemble/messages.interface.en_GB.json
+++ b/src/assemble/messages.interface.en_GB.json
@@ -1,4 +1,8 @@
 {
+  "prefsHeadingInterface": {
+    "message": "Interface"
+  },
+
   "prefsInterface": {
     "message": "Show landmarks in"
   },

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -324,7 +324,6 @@ function bootstrap() {
 	}
 
 	browser.storage.sync.get(defaultDeveloperSettings, function(items) {
-		console.log('CS: setting values...')
 		landmarksFinderStandard.useHeuristics(!items.developerDoNotGuess)
 		landmarksFinderDeveloper.useHeuristics(!items.developerDoNotGuess)
 	})
@@ -333,7 +332,6 @@ function bootstrap() {
 		if ('developerDoNotGuess' in changes) {
 			const change = changes.developerDoNotGuess
 			if (change.newValue !== change.oldValue) {
-				console.log('CS: dev opt changed from', change.oldValue, 'to', change.newValue)
 				landmarksFinderStandard.useHeuristics(!change.newValue)
 				landmarksFinderDeveloper.useHeuristics(!change.newValue)
 				findLandmarks(noop, noop)

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -6,9 +6,10 @@ import PauseHandler from './pauseHandler'
 import BorderDrawer from './borderDrawer'
 import ContrastChecker from './contrastChecker'
 import MutationStatsReporter from './mutationStatsReporter'
+import { defaultDeveloperSettings } from './defaults'
 
-const landmarksFinderStandard = new Standard(window, document, true)
-const landmarksFinderDeveloper = new Developer(window, document, true)
+const landmarksFinderStandard = new Standard(window, document)
+const landmarksFinderDeveloper = new Developer(window, document)
 const contrastChecker = new ContrastChecker()
 const borderDrawer = new BorderDrawer(window, document, contrastChecker)
 const elementFocuser = new ElementFocuser(document, borderDrawer)
@@ -321,6 +322,20 @@ function bootstrap() {
 				document.removeEventListener('visibilitychange', reflectPageVisibility, false)
 			})
 	}
+
+	browser.storage.sync.get(defaultDeveloperSettings, function(items) {
+		console.log('CS: setting values...')
+		landmarksFinderStandard.useHeuristics(!items['developerDoNotGuess'])
+		landmarksFinderDeveloper.useHeuristics(!items['developerDoNotGuess'])
+	})
+
+	browser.storage.onChanged.addListener(function(changes) {
+		if ('developerDoNotGuess' in changes) {
+			console.log('CS: dev opt changed...')
+			landmarksFinderStandard.useHeuristics(!changes.developerDoNotGuess.newValue)
+			landmarksFinderDeveloper.useHeuristics(!changes.developerDoNotGuess.newValue)
+		}
+	})
 
 	createMutationObserver()
 	// Requesting the DevTools' state will eventually cause the correct scanner

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -6,7 +6,7 @@ import PauseHandler from './pauseHandler'
 import BorderDrawer from './borderDrawer'
 import ContrastChecker from './contrastChecker'
 import MutationStatsReporter from './mutationStatsReporter'
-import { defaultDeveloperSettings } from './defaults'
+import { defaultFunctionalSettings } from './defaults'
 
 const landmarksFinderStandard = new Standard(window, document)
 const landmarksFinderDeveloper = new Developer(window, document)
@@ -333,11 +333,12 @@ function startUpTasks() {
 	}
 
 	browser.storage.onChanged.addListener(function(changes) {
-		if ('developerDoNotGuess' in changes) {
-			const change = changes.developerDoNotGuess
-			if (change.newValue !== change.oldValue) {
-				landmarksFinderStandard.useHeuristics(!change.newValue)
-				landmarksFinderDeveloper.useHeuristics(!change.newValue)
+		if ('guessLandmarks' in changes) {
+			const setting = changes.guessLandmarks.newValue ??
+				defaultFunctionalSettings.guessLandmarks
+			if (setting !== changes.guessLandmarks.oldValue) {
+				landmarksFinderStandard.useHeuristics(setting)
+				landmarksFinderDeveloper.useHeuristics(setting)
 				findLandmarks(noop, noop)
 			}
 		}
@@ -351,8 +352,8 @@ function startUpTasks() {
 }
 
 debugSend(`starting - ${window.location}`)
-browser.storage.sync.get(defaultDeveloperSettings, function(items) {
-	landmarksFinderStandard.useHeuristics(!items.developerDoNotGuess)
-	landmarksFinderDeveloper.useHeuristics(!items.developerDoNotGuess)
+browser.storage.sync.get(defaultFunctionalSettings, function(items) {
+	landmarksFinderStandard.useHeuristics(items.guessLandmarks)
+	landmarksFinderDeveloper.useHeuristics(items.guessLandmarks)
 	startUpTasks()
 })

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -325,15 +325,19 @@ function bootstrap() {
 
 	browser.storage.sync.get(defaultDeveloperSettings, function(items) {
 		console.log('CS: setting values...')
-		landmarksFinderStandard.useHeuristics(!items['developerDoNotGuess'])
-		landmarksFinderDeveloper.useHeuristics(!items['developerDoNotGuess'])
+		landmarksFinderStandard.useHeuristics(!items.developerDoNotGuess)
+		landmarksFinderDeveloper.useHeuristics(!items.developerDoNotGuess)
 	})
 
 	browser.storage.onChanged.addListener(function(changes) {
 		if ('developerDoNotGuess' in changes) {
-			console.log('CS: dev opt changed...')
-			landmarksFinderStandard.useHeuristics(!changes.developerDoNotGuess.newValue)
-			landmarksFinderDeveloper.useHeuristics(!changes.developerDoNotGuess.newValue)
+			const change = changes.developerDoNotGuess
+			if (change.newValue !== change.oldValue) {
+				console.log('CS: dev opt changed from', change.oldValue, 'to', change.newValue)
+				landmarksFinderStandard.useHeuristics(!change.newValue)
+				landmarksFinderDeveloper.useHeuristics(!change.newValue)
+				findLandmarks(noop, noop)
+			}
 		}
 	})
 

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -11,7 +11,7 @@ import { defaultSettings, defaultDismissalStates } from './defaults'
 
 const options = [{
 	name: 'borderType',
-	kind: 'radio'
+	kind: 'choice'
 }, {
 	name: 'borderColour',
 	kind: 'individual',
@@ -33,14 +33,14 @@ function restoreOptions() {
 			const saved = items[name]
 
 			switch (option.kind) {
-				case 'radio':
+				case 'choice':
 					document.getElementById(`radio-${saved}`).checked = true
-					break
-				case 'boolean':
-					option.element.checked = saved
 					break
 				case 'individual':
 					option.element.value = saved
+					break
+				case 'boolean':
+					option.element.checked = saved
 					break
 				default:
 					console.error(`Unexpected option kind '${option.kind}'`)
@@ -132,7 +132,7 @@ function main() {
 	if (BROWSER === 'firefox' || BROWSER === 'opera') {
 		options.push({
 			name: 'interface',
-			kind: 'radio'
+			kind: 'choice'
 		})
 
 		if (BROWSER === 'opera') {

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -15,11 +15,15 @@ const options = [{
 }, {
 	name: 'borderColour',
 	kind: 'individual',
-	element: document.getElementById('border-colour'),
+	element: document.getElementById('border-colour')
 }, {
 	name: 'borderFontSize',
 	kind: 'individual',
-	element: document.getElementById('border-font-size'),
+	element: document.getElementById('border-font-size')
+}, {
+	name: 'developerDoNotGuess',
+	kind: 'boolean',
+	element: document.getElementById('developer-do-not-guess')
 }]
 
 function restoreOptions() {
@@ -31,6 +35,9 @@ function restoreOptions() {
 			switch (option.kind) {
 				case 'radio':
 					document.getElementById(`radio-${saved}`).checked = true
+					break
+				case 'boolean':
+					option.element.checked = saved
 					break
 				case 'individual':
 					option.element.value = saved
@@ -44,12 +51,23 @@ function restoreOptions() {
 
 function setUpOptionHandlers() {
 	for (const option of options) {
-		if (option.kind === 'individual') {
-			option.element.addEventListener('change', () => {
-				browser.storage.sync.set({
-					[option.name]: option.element.value
+		switch (option.kind) {
+			case 'individual':
+				option.element.addEventListener('change', () => {
+					browser.storage.sync.set({
+						[option.name]: option.element.value
+					})
 				})
-			})
+				break
+			case 'boolean':
+				option.element.addEventListener('change', () => {
+					browser.storage.sync.set({
+						[option.name]: option.element.checked
+					})
+				})
+				break
+			default:
+				// Choice (radio button) options are handled below.
 		}
 	}
 

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -21,9 +21,9 @@ const options = [{
 	kind: 'individual',
 	element: document.getElementById('border-font-size')
 }, {
-	name: 'developerDoNotGuess',
+	name: 'guessLandmarks',
 	kind: 'boolean',
-	element: document.getElementById('developer-do-not-guess')
+	element: document.getElementById('guess-landmarks')
 }]
 
 function restoreOptions() {

--- a/src/code/defaults.js
+++ b/src/code/defaults.js
@@ -13,8 +13,8 @@ export const defaultInterfaceSettings =
 		? Object.freeze({ interface: 'popup' })
 		: null
 
-export const defaultDeveloperSettings = Object.freeze({
-	developerDoNotGuess: false
+export const defaultFunctionalSettings = Object.freeze({
+	guessLandmarks: true
 })
 
 export const defaultSettings =
@@ -22,10 +22,10 @@ export const defaultSettings =
 		? Object.freeze(Object.assign({},
 			defaultBorderSettings,
 			defaultInterfaceSettings,
-			defaultDeveloperSettings))
+			defaultFunctionalSettings))
 		: Object.freeze(Object.assign({},
 			defaultBorderSettings,
-			defaultDeveloperSettings))
+			defaultFunctionalSettings))
 
 
 //

--- a/src/code/defaults.js
+++ b/src/code/defaults.js
@@ -13,12 +13,19 @@ export const defaultInterfaceSettings =
 		? Object.freeze({ interface: 'popup' })
 		: null
 
+export const defaultDeveloperSettings = Object.freeze({
+	developerDoNotGuess: false
+})
+
 export const defaultSettings =
 	(BROWSER === 'firefox' || BROWSER === 'opera')
 		? Object.freeze(Object.assign({},
 			defaultBorderSettings,
-			defaultInterfaceSettings))
-		: Object.freeze(defaultBorderSettings)
+			defaultInterfaceSettings,
+			defaultDeveloperSettings))
+		: Object.freeze(Object.assign({},
+			defaultBorderSettings,
+			defaultDeveloperSettings))
 
 
 //

--- a/src/static/common.css
+++ b/src/static/common.css
@@ -14,6 +14,7 @@
 
 	/* Lengths */
 	--base-font-size: 1.5rem;
+	--radio-and-tick-scale-factor: 1.5;  /* Needs to match the font size */
 	--line-height: 1.5;
 	--thickness: 0.2rem;
 	--secondary-thickness: 0.1rem;

--- a/src/static/options.css
+++ b/src/static/options.css
@@ -1,4 +1,7 @@
-main > * + * { margin-top: 1rem; }
+main > * + :not(h2) { margin-top: 1rem; }
+
+input[type="radio"],
+input[type="checkbox"] { transform: scale(var(--radio-and-tick-scale-factor)); }
 
 button[aria-pressed="true"] {
 	background-color: var(--accent-1);
@@ -10,19 +13,19 @@ fieldset > * + * { margin-top: 0.5rem; }
 .field-radio {
 	display: flex;
 	align-items: center;
+	gap: 1em;
 }
 
 .field-radio label {
-	margin-left: 0.5rem;
 	flex-grow: 1;
 }
 
-fieldset label p {
+label p {
 	margin: 0;
 	margin-bottom: 0.25rem;
 }
 
-fieldset label p:first-child { font-weight: bold; }
+label p:first-child { font-weight: bold; }
 
 fieldset > :last-child { margin-bottom: 0.5rem; }
 

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -15,13 +15,15 @@
 
 		<main>
 			<!-- sidebar -->
+			<h2>Interface</h2>
+
 			<fieldset data-pref="interface">
 				<legend data-message="prefsInterface"></legend>
 
 				<div class="field-radio">
 					<input type="radio" name="interface" value="popup" id="radio-popup">
 					<label for="radio-popup">
-						<p data-message="prefsPopup"></p>
+						<p data-message="prefsPopup"></p><span class="visually-hidden">.</span>
 						<p data-message="prefsPopupExplanation"></p>
 					</label>
 				</div>
@@ -29,12 +31,15 @@
 				<div class="field-radio">
 					<input type="radio" name="interface" value="sidebar" id="radio-sidebar">
 					<label for="radio-sidebar">
-						<p data-message="prefsSidebar"></p>
+						<p data-message="prefsSidebar"></p><span class="visually-hidden">.</span>
+
 						<p data-message="prefsSidebarExplanation"></p>
 					</label>
 				</div>
 			</fieldset>
 			<!-- /sidebar -->
+
+			<h2>Border appearance</h2>
 
 			<fieldset data-pref="borderType">
 				<legend data-message="prefsBorderType"></legend>
@@ -63,15 +68,18 @@
 				<input type="number" id="border-font-size">
 			</div>
 
-			<fieldset>
-				<legend data-message="prefsDeveloper"></legend>
+			<h2>Functionality</h2>
 
-				<div class="field-radio">
-					<input type="checkbox" id="developer-do-not-guess">
-					<label for="developer-do-not-guess" data-message="prefsDeveloperDoNotGuess"></label>
-					</label>
-				</div>
-			</fieldset>
+			<div class="field-radio">
+				<input type="checkbox" id="guess-landmarks">
+				<label for="guess-landmarks">
+					<p data-message="prefsGuessLandmarks"></p><span class="visually-hidden">.</span>
+
+					<p data-message="prefsGuessLandmarksInfo"></p>
+				</label>
+			</div>
+
+			<h2>Resetting stuff</h2>
 
 			<div>
 				<button id="reset-messages" data-message="prefsResetMessages" aria-describedby="reset-messages-feedback"></button>

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -63,6 +63,16 @@
 				<input type="number" id="border-font-size" data-pref="borderFontSize">
 			</div>
 
+			<fieldset>
+				<legend data-message="prefsDeveloper"></legend>
+
+				<div class="field-radio">
+					<input type="checkbox" id="developer-do-not-guess">
+					<label for="developer-do-not-guess" data-message="prefsDeveloperDoNotGuess"></label>
+					</label>
+				</div>
+			</fieldset>
+
 			<div>
 				<button id="reset-messages" data-message="prefsResetMessages" aria-describedby="reset-messages-feedback"></button>
 				<span aria-live="polite" id="reset-messages-feedback"></span>

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -15,7 +15,7 @@
 
 		<main>
 			<!-- sidebar -->
-			<h2>Interface</h2>
+			<h2 data-message="prefsHeadingInterface"></h2>
 
 			<fieldset data-pref="interface">
 				<legend data-message="prefsInterface"></legend>
@@ -39,7 +39,7 @@
 			</fieldset>
 			<!-- /sidebar -->
 
-			<h2>Border appearance</h2>
+			<h2 data-message="prefsHeadingBorder"></h2>
 
 			<fieldset data-pref="borderType">
 				<legend data-message="prefsBorderType"></legend>
@@ -68,7 +68,7 @@
 				<input type="number" id="border-font-size">
 			</div>
 
-			<h2>Functionality</h2>
+			<h2 data-message="prefsHeadingFunctionality"></h2>
 
 			<div class="field-radio">
 				<input type="checkbox" id="guess-landmarks">
@@ -79,7 +79,7 @@
 				</label>
 			</div>
 
-			<h2>Resetting stuff</h2>
+			<h2 data-message="prefsHeadingReset"></h2>
 
 			<div>
 				<button id="reset-messages" data-message="prefsResetMessages" aria-describedby="reset-messages-feedback"></button>

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -57,10 +57,10 @@
 
 			<div id="gird">
 				<label for="border-colour" data-message="prefsBorderColour"></label>
-				<input type="color" id="border-colour" data-pref="borderColor">
+				<input type="color" id="border-colour">
 
 				<label for="border-font-size" data-message="prefsBorderFontSize"></label>
-				<input type="number" id="border-font-size" data-pref="borderFontSize">
+				<input type="number" id="border-font-size">
 			</div>
 
 			<fieldset>


### PR DESCRIPTION
This addresses makes the use of heuristics an option that is on by default. It also re-organises the preferences page a bit to accommodate this. The radio buttons and checkboxes are enlarged in line with the rest of the text on the preferences page.

The content script code was cleaned up a little.

Fixes #457