### PR TITLE
fix: Ensure pages loaded in the foreground tab are monitored for changes

### DIFF
--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -21,7 +21,6 @@ const observerReconnectionGrace = 2e3  // wait after page becomes visible again
 let observerReconnectionScanTimer = null
 let observer = null
 let landmarksFinder = landmarksFinderStandard  // just in case
-let haveScannedForLandmarks = false
 
 
 //
@@ -98,7 +97,6 @@ function messageHandler(message) {
 			findLandmarksAndSend(
 				// TODO: this willl send the non-mutation message twice
 				msr.incrementNonMutationScans, msr.sendAllUpdates)
-			// haveScannedForLandmarks will be set to true now anyway
 			break
 		case 'devtools-state':
 			if (message.state === 'open') {
@@ -128,7 +126,7 @@ function messageHandler(message) {
 
 function doUpdateOutdatedResults() {
 	let outOfDate = false
-	if (observerReconnectionScanTimer !== null && !haveScannedForLandmarks) {
+	if (observerReconnectionScanTimer !== null) {
 		debugSend('out-of-date: no scan yet + waiting to observe')
 		cancelObserverReconnectionScan()
 		observeMutations()
@@ -186,7 +184,6 @@ function findLandmarks(counterIncrementFunction, updateSendFunction) {
 
 	const start = performance.now()
 	landmarksFinder.find()
-	if (!haveScannedForLandmarks) haveScannedForLandmarks = true
 	msr.setLastScanDuration(performance.now() - start)
 
 	counterIncrementFunction()

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -113,7 +113,8 @@ function messageHandler(message) {
 				throw Error(`Invalid DevTools state "${message.state}".`)
 			}
 			if (!document.hidden) {
-				debugSend('doc visible; also scanning')
+				debugSend('doc visible; also observing and scanning')
+				observeMutations()  // OK to call again
 				findLandmarks(noop, noop)
 			}
 			break
@@ -346,8 +347,9 @@ function startUpTasks() {
 
 	createMutationObserver()
 
-	// Requesting the DevTools' state will eventually cause the correct
-	// scanner to be set, and the document to be scanned, if visible.
+	// Requesting the DevTools' state will eventually cause the correct scanner
+	// to be set, the observer to be hooked up, and the document to be scanned,
+	// if visible.
 	browser.runtime.sendMessage({ name: 'get-devtools-state' })
 }
 


### PR DESCRIPTION
PR #428 introduced a bug whereby the MutationObserver wouldn't be wired up until the page became visible (i.e. either the user moves to it for the first time, if it was loaded in a background tab, or the user moves away from and back to it, if it was loaded in the foreground tab). This was discovered and reported by @cbou in #458.

Fixes #458