### PR TITLE
fix: Support the "role" attribute correctly as a token list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "landmarks",
       "version": "2.11.0",
       "devDependencies": {
         "@rollup/plugin-strip": "^2.1.0",
@@ -20,7 +21,7 @@
         "glob": "^7.1.7",
         "husky": "^7.0.1",
         "jsdom": "^16.6.0",
-        "page-structural-semantics-scanner-tests": "git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#0.7.0",
+        "page-structural-semantics-scanner-tests": "git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#0.8.0",
         "prettier": "^2.3.2",
         "puppeteer": "^10.0.0",
         "replace-in-file": "^6.2.0",
@@ -19753,7 +19754,7 @@
     "page-structural-semantics-scanner-tests": {
       "version": "git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#436fc363909b51326d15e00ce4a602aec410de44",
       "dev": true,
-      "from": "page-structural-semantics-scanner-tests@git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#0.7.0"
+      "from": "page-structural-semantics-scanner-tests@git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#0.8.0"
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "glob": "^7.1.7",
     "husky": "^7.0.1",
     "jsdom": "^16.6.0",
-    "page-structural-semantics-scanner-tests": "git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#0.7.0",
+    "page-structural-semantics-scanner-tests": "git+https://git@github.com/matatk/page-structural-semantics-scanner-tests.git#0.8.0",
     "prettier": "^2.3.2",
     "puppeteer": "^10.0.0",
     "replace-in-file": "^6.2.0",

--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -137,8 +137,8 @@ export default function LandmarksFinder(win, doc, _testUseHeuristics) {
 		let explicitRole = false
 
 		// Elements with explicitly-set rolees
-		if (element.getAttribute) {
-			const tempRole = element.getAttribute('role')
+		if (element.getAttribute) {  // FIXME/TODO: why is this check needed?
+			const tempRole = getValidExplicitRole(element)
 			if (tempRole) {
 				role = tempRole
 				explicitRole = true
@@ -205,93 +205,6 @@ export default function LandmarksFinder(win, doc, _testUseHeuristics) {
 		}
 	}
 
-	function getARIAProvidedLabel(element) {
-		let label = null
-
-		// TODO general whitespace test?
-		const idRefs = element.getAttribute('aria-labelledby')
-		if (idRefs !== null && idRefs.length > 0) {
-			const innerTexts = Array.from(idRefs.split(' '), idRef => {
-				const labelElement = doc.getElementById(idRef)
-				return getInnerText(labelElement)
-			})
-			label = innerTexts.join(' ')
-		}
-
-		if (label === null) {
-			label = element.getAttribute('aria-label')
-		}
-
-		return label
-	}
-
-	function isLandmark(role, explicitRole, label) {
-		// <section> and <form> are only landmarks when labelled.
-		// <div role="form"> is always a landmark.
-		if (role === 'region' || (role === 'form' && !explicitRole)) {
-			return label !== null
-		}
-
-		// Is the role (which may've been explicitly set) a valid landmark type?
-		return regionTypes.includes(role)
-	}
-
-	function getInnerText(element) {
-		let text = null
-
-		if (element) {
-			text = element.innerText
-			if (text === undefined) {
-				text = element.textContent
-			}
-		}
-
-		return text
-	}
-
-	function getRoleFromTagNameAndContainment(element) {
-		const name = element.tagName
-		let role = null
-
-		if (name) {
-			if (implicitRoles.hasOwnProperty(name)) {
-				role = implicitRoles[name]
-			}
-
-			// <header> and <footer> elements have some containment-
-			// related constraints on whether they're counted as landmarks
-			if (name === 'HEADER' || name === 'FOOTER') {
-				if (!isChildOfTopLevelSection(element)) {
-					role = null
-				}
-			}
-		}
-
-		return role
-	}
-
-	function getRoleDescription(element) {
-		const roleDescription = element.getAttribute('aria-roledescription')
-		// TODO make this a general whitespace check?
-		if (/^\s*$/.test(roleDescription)) {
-			return null
-		}
-		return roleDescription
-	}
-
-	function isChildOfTopLevelSection(element) {
-		let ancestor = element.parentNode
-
-		while (ancestor !== null) {
-			if (nonBodySectioningElementsAndMain.includes(ancestor.tagName)) {
-				return false
-			}
-			ancestor = ancestor.parentNode
-		}
-
-		return true
-	}
-
 	// TODO: Check if we need this at all?
 	// Note: This only checks the element itself: it won't reflect if this
 	//       element is contained in another that _is_ visually hidden. So far
@@ -317,6 +230,112 @@ export default function LandmarksFinder(win, doc, _testUseHeuristics) {
 			return true
 		}
 		return false
+	}
+
+	function getRoleFromTagNameAndContainment(element) {
+		const name = element.tagName
+		let role = null
+
+		if (name) {
+			if (implicitRoles.hasOwnProperty(name)) {
+				role = implicitRoles[name]
+			}
+
+			// <header> and <footer> elements have some containment-
+			// related constraints on whether they're counted as landmarks
+			if (name === 'HEADER' || name === 'FOOTER') {
+				if (!isChildOfTopLevelSection(element)) {
+					role = null
+				}
+			}
+		}
+
+		return role
+	}
+
+	function isChildOfTopLevelSection(element) {
+		let ancestor = element.parentNode
+
+		while (ancestor !== null) {
+			if (nonBodySectioningElementsAndMain.includes(ancestor.tagName)) {
+				return false
+			}
+			ancestor = ancestor.parentNode
+		}
+
+		return true
+	}
+
+	function getValidExplicitRole(element) {
+		const value = element.getAttribute('role')  // FIXME: test passing just attribute value string?
+
+		if (value) {
+			if (value.indexOf(' ') >= 0) {
+				const roles = value.split(' ')
+				for (const role of roles) {
+					if (regionTypes.includes(role)) {
+						return role
+					}
+				}
+			} else if (regionTypes.includes(value)) {
+				return value
+			}
+		}
+
+		return null
+	}
+
+	function getARIAProvidedLabel(element) {
+		let label = null
+
+		// TODO general whitespace test?
+		const idRefs = element.getAttribute('aria-labelledby')
+		if (idRefs !== null && idRefs.length > 0) {
+			const innerTexts = Array.from(idRefs.split(' '), idRef => {
+				const labelElement = doc.getElementById(idRef)
+				return getInnerText(labelElement)
+			})
+			label = innerTexts.join(' ')
+		}
+
+		if (label === null) {
+			label = element.getAttribute('aria-label')
+		}
+
+		return label
+	}
+
+	function getInnerText(element) {
+		let text = null
+
+		if (element) {
+			text = element.innerText
+			if (text === undefined) {
+				text = element.textContent
+			}
+		}
+
+		return text
+	}
+
+	function isLandmark(role, explicitRole, label) {
+		// <section> and <form> are only landmarks when labelled.
+		// <div role="form"> is always a landmark.
+		if (role === 'region' || (role === 'form' && !explicitRole)) {
+			return label !== null
+		}
+
+		// Is the role (which may've been explicitly set) a valid landmark type?
+		return regionTypes.includes(role)  // FIXME: no longer needed; test diff
+	}
+
+	function getRoleDescription(element) {
+		const roleDescription = element.getAttribute('aria-roledescription')
+		// TODO make this a general whitespace check?
+		if (/^\s*$/.test(roleDescription)) {
+			return null
+		}
+		return roleDescription
 	}
 
 	function createSelector(element) {

--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -324,9 +324,7 @@ export default function LandmarksFinder(win, doc, _testUseHeuristics) {
 		if (role === 'region' || (role === 'form' && !explicitRole)) {
 			return label !== null
 		}
-
-		// Is the role (which may've been explicitly set) a valid landmark type?
-		return regionTypes.includes(role)  // FIXME: no longer needed; test diff
+		return true  // already a valid role if we were called
 	}
 
 	function getRoleDescription(element) {

--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -137,7 +137,7 @@ export default function LandmarksFinder(win, doc, _testUseHeuristics) {
 		let explicitRole = false
 
 		// Elements with explicitly-set rolees
-		if (element.getAttribute) {  // FIXME/TODO: why is this check needed?
+		if (element.getAttribute) {  // TODO: why is this check needed?
 			const tempRole = getValidExplicitRole(element)
 			if (tempRole) {
 				role = tempRole
@@ -267,7 +267,7 @@ export default function LandmarksFinder(win, doc, _testUseHeuristics) {
 	}
 
 	function getValidExplicitRole(element) {
-		const value = element.getAttribute('role')  // FIXME: test passing just attribute value string?
+		const value = element.getAttribute('role')
 
 		if (value) {
 			if (value.indexOf(' ') >= 0) {

--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -289,6 +289,7 @@ export default function LandmarksFinder(win, doc, _testUseHeuristics) {
 		let label = null
 
 		// TODO general whitespace test?
+		// TODO if some IDs don't exist, this will include nulls - test?
 		const idRefs = element.getAttribute('aria-labelledby')
 		if (idRefs !== null && idRefs.length > 0) {
 			const innerTexts = Array.from(idRefs.split(' '), idRef => {


### PR DESCRIPTION
* Handle the `role` attribute as a token list.
* Bump page-structural-semantics-scanner-tests to include token list tests.
* Don't check for valid roles twice (checked performance; seems negligible, but definitely was duplicated work).
* Move some of the functions around so that definition order matches order called in `getLandmarks()`.
* Add a couple of TODO notes.

Fixes #464