### PR TITLE
feat: Highlight landmark on button focus or hover

### DIFF
--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -41,6 +41,13 @@ function messageHandler(message) {
 			guiCheckFocusElement(() =>
 				landmarksFinder.getLandmarkElementInfo(message.index))
 			break
+		case 'show-landmark':
+			borderDrawer.replaceCurrentBordersWithElements(
+				[landmarksFinder.getLandmarkElementInfo(message.index)])
+			break
+		case 'hide-all-landmarks':
+			borderDrawer.removeAllBorders()
+			break
 		case 'next-landmark':
 			// Triggered by keyboard shortcut
 			doUpdateOutdatedResults()

--- a/src/code/_content.js
+++ b/src/code/_content.js
@@ -42,11 +42,15 @@ function messageHandler(message) {
 				landmarksFinder.getLandmarkElementInfo(message.index))
 			break
 		case 'show-landmark':
-			borderDrawer.replaceCurrentBordersWithElements(
-				[landmarksFinder.getLandmarkElementInfo(message.index)])
+			if (elementFocuser.isManagingBorders()) {
+				borderDrawer.replaceCurrentBordersWithElements(
+					[landmarksFinder.getLandmarkElementInfo(message.index)])
+			}
 			break
 		case 'hide-all-landmarks':
-			borderDrawer.removeAllBorders()
+			if (elementFocuser.isManagingBorders()) {
+				borderDrawer.removeAllBorders()
+			}
 			break
 		case 'next-landmark':
 			// Triggered by keyboard shortcut

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -106,12 +106,22 @@ function makeLandmarksTree(landmarks, container) {
 
 		// If nesting hasn't changed, stick with the current base
 
+		const shower = function() {
+			send({ name: 'show-landmark', index: index })
+		}
+
+		const hider = function() {
+			send({ name: 'hide-all-landmarks' })
+		}
+
 		// Create the <li> for this landmark
 		const item = document.createElement('li')
-		const button = makeButton(
+		const button = makeLandmarkButton(
 			function() {
 				send({ name: 'focus-landmark', index: index })
 			},
+			shower,
+			hider,
 			landmarkName(landmark))
 		item.appendChild(button)
 
@@ -143,7 +153,7 @@ function makeLandmarksTree(landmarks, container) {
 }
 
 function addInspectButton(root, landmark) {
-	const inspectButton = makeButton(
+	const inspectButton = makeInspectButton(
 		function() {
 			const inspectorCall = "inspect(document.querySelector('"
 				+ landmark.selector  // comes from our own code
@@ -184,14 +194,21 @@ function addText(element, message) {
 	element.appendChild(newPara)
 }
 
-function makeButton(onClick, text, cssClass, context) {
+function makeLandmarkButton(onClick, shower, hider, text) {
 	const button = document.createElement('button')
-	if (cssClass && context) {
-		button.className = cssClass
-		button.setAttribute('aria-label', text + ' ' + context)
-	} else {
-		button.appendChild(document.createTextNode(text))
-	}
+	button.appendChild(document.createTextNode(text))
+	button.addEventListener('click', onClick)
+	button.addEventListener('focus', shower)
+	button.addEventListener('mouseenter', shower)
+	button.addEventListener('blur', hider)
+	button.addEventListener('mouseleave', hider)
+	return button
+}
+
+function makeInspectButton(onClick, text, cssClass, context) {
+	const button = document.createElement('button')
+	button.className = cssClass
+	button.setAttribute('aria-label', text + ' ' + context)
 	button.addEventListener('click', onClick)
 	return button
 }

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -107,11 +107,11 @@ function makeLandmarksTree(landmarks, container) {
 		// If nesting hasn't changed, stick with the current base
 
 		const shower = function() {
-			send({ name: 'show-landmark', index: index })
+			send({ name: 'show-landmark', index })
 		}
 
 		const hider = function() {
-			send({ name: 'hide-all-landmarks' })
+			send({ name: 'hide-landmark', index })
 		}
 
 		// Create the <li> for this landmark

--- a/src/static/help.html
+++ b/src/static/help.html
@@ -54,10 +54,13 @@
 				<h2>What's new?</h2>
 				<p>New in version <span id="version"></span>&hellip;</p>
 				<ul>
-					<li>Correctly support the <code>role</code> attribute, which can take multiple values. <a href="https://github.com/matatk/landmarks/issues/464">Thanks for the bug report, James Nurthen</a>.</li>
-					<li>Fix DevTools pane colours in dark mode. <a href="https://github.com/matatk/landmarks/issues/466">Thanks for the bug report, Andrew Nevins</a>.</li>
-					<li>Reinstate the sidebar on Opera (the browser bug has been fixed).</li>
-					<li>Minor performance improvements.</li>
+					<li>Visually highlight landmarks when their corresponding buttons in the sidebar (Firefox) or pop-up (all browsers) are focused/hovered. A couple more details&hellip;
+						<ul>
+							<li>The page won't scroll when highlighting landmarks in this way, to prevent jumpiness.</li>
+							<li>The rate at which the highlights are applied/removed is capped, to prevent excessive flashing.</li>
+						</ul>
+					</li>
+					<li>TBD</li>
 				</ul>
 				<p>For full details, consult the <a href="https://github.com/matatk/landmarks/blob/master/CHANGELOG.md#changelog">change log</a>.</p>
 			</div>


### PR DESCRIPTION
* Draw the border—but don't scroll the page—when focusing on, or hovering over, a landmark button in the GUI.
* Don't allow the border addition/removal to flash excessively.
* Add documentation for the next release.