### PR TITLE
feat: Option to close the pop-up immediately on using a landmark button

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:all": "node scripts/build.js --browser all",
     "clean:builds": "node scripts/build.js --browser all --clean-only",
     "profile": "node scripts/profile.js",
-    "start:_core": "web-ext --no-config-discovery run --start-url https://matatk.agrip.org.uk/landmarks/world-of-wombats/",
+    "start:_core": "web-ext --no-config-discovery run --start-url https://matatk.agrip.org.uk/landmarks/world-of-wombats/ --browser-console",
     "start:chrome": "npm run start:_core -- --source-dir build/chrome --target chromium",
     "start:edge": "npm run start:_core -- --source-dir build/edge --target chromium --chromium-binary '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'",
     "start:firefox": "npm run start:_core -- --source-dir build/firefox",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -327,7 +327,7 @@ function copyStaticFiles(browser) {
 
 
 function copyGuiFiles(browser) {
-	logStep('Copying root GUI HTML to create the popup and other bits')
+	logStep('Copying root GUI HTML to create the pop-up and other bits')
 
 	function copyOneGuiFile(destination, isSidebar, isDevTools) {
 		const destHtml = path.join(pathToBuild(browser), `${destination}.html`)
@@ -339,7 +339,7 @@ function copyGuiFiles(browser) {
 			`Referenced ${destination} code`)
 
 		// The general gui.html file is organised such that non-DevTools stuff
-		// is always wrapped in a popup-and-sidebar block.
+		// is always wrapped in a 'popup-and-sidebar' block.
 		if (isDevTools) {
 			removeStuff('pop-up and sidebar', 'popup-and-sidebar', destHtml)
 		} else {

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -112,6 +112,14 @@
     "message": "If you're a developer or accessibility auditor, you may wish to disable this, as guessed landmarks are counted in the toolbar badge. Regardless of this setting, relevant warnings are always shown in the Landmarks DevTools side pane."
   },
 
+  "prefsClosePopupOnActivate": {
+    "message": "Close the pop-up immediately when activating a landmark button"
+  },
+
+  "prefsClosePopupOnActivateInfo": {
+    "message": "Instead of keeping the pop-up open, close it and move focus to the selected landmark on the page, so you can start navigating directly from there."
+  },
+
   "prefsHeadingReset": {
     "message": "Resetting stuff"
   },

--- a/src/assemble/messages.common.en_GB.json
+++ b/src/assemble/messages.common.en_GB.json
@@ -117,7 +117,7 @@
   },
 
   "prefsClosePopupOnActivateInfo": {
-    "message": "Instead of keeping the pop-up open, close it and move focus to the selected landmark on the page, so you can start navigating directly from there."
+    "message": "Instead of having to manually close the pop-up before continuing to navigate the page, turning this on closes the pop-up automatically."
   },
 
   "prefsHeadingReset": {

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -3,9 +3,12 @@
 import './compatibility'
 import translate from './translate'
 import landmarkName from './landmarkName'
-import { defaultInterfaceSettings, defaultDismissalStates, defaultDismissedSidebarNotAlone } from './defaults'
+import { defaultInterfaceSettings, defaultDismissalStates, defaultDismissedSidebarNotAlone, defaultFunctionalSettings } from './defaults'
 import { isContentScriptablePage } from './isContent'
 import { withActiveTab } from './withTabs'
+
+// TODO: check how this looks in the built code
+let closePopupOnActivate = defaultFunctionalSettings.closePopupOnActivate
 
 const _sidebarNote = {
 	'dismissedSidebarNotAlone': {
@@ -119,6 +122,10 @@ function makeLandmarksTree(landmarks, container) {
 		const button = makeLandmarkButton(
 			function() {
 				send({ name: 'focus-landmark', index: index })
+				// TODO: check how this looks in the built code
+				if (INTERFACE === 'popup' && closePopupOnActivate) {
+					window.close()
+				}
 			},
 			shower,
 			hider,
@@ -467,6 +474,15 @@ function startupPopupOrSidebar() {
 		browser.runtime.getManifest().version
 
 	setupNotes()
+
+	// Get user's chosen values for FIXME.
+	//
+	// NOTE: We don't need to monitor for changes, because only the popup is
+	// affected by this setting, and the user almost certainly won't change a
+	// popup-related setting whilst a popup is open.
+	browser.storage.sync.get(defaultFunctionalSettings, function(items) {
+		closePopupOnActivate = items['closePopupOnActivate']
+	})
 }
 
 function main() {

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -477,9 +477,9 @@ function startupPopupOrSidebar() {
 
 	// Get user's chosen values for FIXME.
 	//
-	// NOTE: We don't need to monitor for changes, because only the popup is
+	// NOTE: We don't need to monitor for changes, because only the pop-up is
 	// affected by this setting, and the user almost certainly won't change a
-	// popup-related setting whilst a popup is open.
+	// pop-up-related setting whilst a pop-up is open.
 	browser.storage.sync.get(defaultFunctionalSettings, function(items) {
 		closePopupOnActivate = items['closePopupOnActivate']
 	})

--- a/src/code/_gui.js
+++ b/src/code/_gui.js
@@ -1,4 +1,4 @@
-// hasOwnProperty is only used on browser-provided objects
+// hasOwnProperty is only used on browser-provided objects and landmarks
 /* eslint-disable no-prototype-builtins */
 import './compatibility'
 import translate from './translate'
@@ -7,8 +7,9 @@ import { defaultInterfaceSettings, defaultDismissalStates, defaultDismissedSideb
 import { isContentScriptablePage } from './isContent'
 import { withActiveTab } from './withTabs'
 
-// TODO: check how this looks in the built code
-let closePopupOnActivate = defaultFunctionalSettings.closePopupOnActivate
+let closePopupOnActivate = INTERFACE === 'popup'
+	? defaultFunctionalSettings.closePopupOnActivate
+	: null
 
 const _sidebarNote = {
 	'dismissedSidebarNotAlone': {
@@ -122,7 +123,6 @@ function makeLandmarksTree(landmarks, container) {
 		const button = makeLandmarkButton(
 			function() {
 				send({ name: 'focus-landmark', index: index })
-				// TODO: check how this looks in the built code
 				if (INTERFACE === 'popup' && closePopupOnActivate) {
 					window.close()
 				}
@@ -475,14 +475,14 @@ function startupPopupOrSidebar() {
 
 	setupNotes()
 
-	// Get user's chosen values for FIXME.
-	//
-	// NOTE: We don't need to monitor for changes, because only the pop-up is
-	// affected by this setting, and the user almost certainly won't change a
-	// pop-up-related setting whilst a pop-up is open.
-	browser.storage.sync.get(defaultFunctionalSettings, function(items) {
-		closePopupOnActivate = items['closePopupOnActivate']
-	})
+	if (INTERFACE === 'popup') {
+		// Get close-on-activate pref. We don't need to monitor for changes:
+		// only the pop-up is affected, and the user almost certainly won't
+		// change a pop-up-related setting whilst a pop-up is open.
+		browser.storage.sync.get(defaultFunctionalSettings, function(items) {
+			closePopupOnActivate = items['closePopupOnActivate']
+		})
+	}
 }
 
 function main() {

--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -24,6 +24,10 @@ const options = [{
 	name: 'guessLandmarks',
 	kind: 'boolean',
 	element: document.getElementById('guess-landmarks')
+}, {
+	name: 'closePopupOnActivate',
+	kind: 'boolean',
+	element: document.getElementById('close-popup-on-activate')
 }]
 
 function restoreOptions() {

--- a/src/code/defaults.js
+++ b/src/code/defaults.js
@@ -14,7 +14,8 @@ export const defaultInterfaceSettings =
 		: null
 
 export const defaultFunctionalSettings = Object.freeze({
-	guessLandmarks: true
+	guessLandmarks: true,
+	closePopupOnActivate: false
 })
 
 export const defaultSettings =

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -79,6 +79,15 @@
 				</label>
 			</div>
 
+			<div class="field-radio">
+				<input type="checkbox" id="close-popup-on-activate">
+				<label for="close-popup-on-activate">
+					<p data-message="prefsClosePopupOnActivate"></p><span class="visually-hidden">.</span>
+
+					<p data-message="prefsClosePopupOnActivateInfo"></p>
+				</label>
+			</div>
+
 			<h2 data-message="prefsHeadingReset"></h2>
 
 			<div>


### PR DESCRIPTION
* Add an option to close the pop-up at the point of activating a landmark's button.
* Ensure "pop-up" is used consistently in the codebase.
* Open the browser console when starting Firefox via web-ext.

Closes #477