### PR TITLE
fix: Validate border size setting

### DIFF
--- a/src/code/_options.js
+++ b/src/code/_options.js
@@ -58,9 +58,13 @@ function setUpOptionHandlers() {
 		switch (option.kind) {
 			case 'individual':
 				option.element.addEventListener('change', () => {
-					browser.storage.sync.set({
-						[option.name]: option.element.value
-					})
+					if (option.element.value) {
+						browser.storage.sync.set({
+							[option.name]: option.element.value
+						})
+					} else {
+						option.element.value = defaultSettings[option.name]
+					}
 				})
 				break
 			case 'boolean':

--- a/src/code/borderDrawer.js
+++ b/src/code/borderDrawer.js
@@ -46,12 +46,10 @@ export default function BorderDrawer(win, doc, contrastChecker) {
 		let needUpdate = false
 		if ('borderColour' in changes) {
 			borderColour = changes.borderColour.newValue
-				?? defaultBorderSettings.borderColour
 			needUpdate = true
 		}
 		if ('borderFontSize' in changes) {
 			borderFontSize = changes.borderFontSize.newValue
-				?? defaultBorderSettings.borderFontSize
 			needUpdate = true
 		}
 		if (needUpdate) {


### PR DESCRIPTION
If the user enters an empty string, the default value is used instead.

Fixes #484