### PR TITLE
fix: Don't un-highlight persistent border

### DIFF
--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -590,4 +590,13 @@ export default function LandmarksFinder(win, doc, _testUseHeuristics) {
 			throw Error(`useHeuristics() given ${typeof use} value: ${use}`)
 		}
 	}
+
+	this.getCurrentlySelectedIndex = function() {
+		return currentlySelectedIndex
+	}
+
+	// TODO: Rename this and the above
+	this.getLandmarkElementInfoWithoutUpdatingIndex = function(index) {
+		return landmarks[index]
+	}
 }


### PR DESCRIPTION
Don't hide the border of the current element when highlighting or un-highlighting via the pop-up when borders are persistent.

Note: if the user has the mouse hovered over a button when the pop-up is closed by pressing the Escape key, that one will remain highlighted. The blur event fires on the button if focused, but apparently the mouseleave event doesn't. It also doesn't seem possible to detect the pop-up window closing.