### PR TITLE
fix: Added a check for a hardcoded aria 'role' value in the same element. 

### DIFF
--- a/src/assemble/_landmarksFinder.js
+++ b/src/assemble/_landmarksFinder.js
@@ -451,21 +451,34 @@ export default function LandmarksFinder(win, doc, _testUseHeuristics) {
 	function tryFindingMain() {
 		if (mainElementIndices.length === 0) {
 			for (const id of ['main', 'content', 'main-content']) {
-				if (addGuessed(doc.getElementById(id), 'main')) return
+				let element = doc.getElementById(id);
+				if (element && element.getAttribute('role') !== 'main') {
+					if (addGuessed(element, 'main')) return;
+				}
 			}
-			const classMains = doc.getElementsByClassName('main')
-			if (classMains.length === 1) addGuessed(classMains[0], 'main')
+			const classMains = doc.getElementsByClassName('main');
+			for (const guessed of classMains) {
+				if (guessed.getAttribute('role') !== 'main') {
+					addGuessed(guessed, 'main');
+				}
+			}
 		}
 	}
+	
 
 	function tryFindingNavs() {
 		if (!foundNavigationRegion) {
 			for (const id of ['navigation', 'nav']) {
-				if (addGuessed(doc.getElementById(id), 'navigation')) break
+				let element = doc.getElementById(id);
+				if(element && element.getAttribute('role') !== 'navigation') {
+					if (addGuessed(element, 'navigation')) break;
+				}
 			}
 			for (const className of ['navigation', 'nav']) {
 				for (const guessed of doc.getElementsByClassName(className)) {
-					addGuessed(guessed, 'navigation')
+					if(guessed.getAttribute('role') !== 'navigation') {
+						addGuessed(guessed, 'navigation');
+					}
 				}
 			}
 		}


### PR DESCRIPTION

This will stop it from "guessing" if an element is a navigation or main element if the element has the aria role of 'navigation' or 'main'. It won't need to guess it if it is specifically outlined to be that.